### PR TITLE
Fix bug in DUAL_X_CARRIAGE

### DIFF
--- a/MK4duo/src/MK_Main.cpp
+++ b/MK4duo/src/MK_Main.cpp
@@ -8886,7 +8886,7 @@ inline void invalid_extruder_error(const uint8_t e) {
               mechanics.hotend_duplication_enabled = false;
               #if ENABLED(DEBUG_LEVELING_FEATURE)
                 if (DEBUGGING(LEVELING)) {
-                  SERIAL_EMV("Set inactive_extruder_x_pos=", inactive_extruder_x_pos);
+                  SERIAL_EMV("Set inactive_hotend_x_pos=", inactive_hotend_x_pos);
                   SERIAL_EM("Clear mechanics.hotend_duplication_enabled");
                 }
               #endif

--- a/MK4duo/src/endstop/endstops.cpp
+++ b/MK4duo/src/endstop/endstops.cpp
@@ -335,11 +335,11 @@ void Endstops::clamp_to_software_endstops(float target[XYZ]) {
           soft_endstop_min[X_AXIS] = X2_MIN_POS + offs;
           soft_endstop_max[X_AXIS] = dual_max_x + offs;
         }
-        else if (dual_x_carriage_mode == DXC_DUPLICATION_MODE) {
+        else if (mechanics.dual_x_carriage_mode == DXC_DUPLICATION_MODE) {
           // In Duplication Mode, T0 can move as far left as X_MIN_POS
           // but not so far to the right that T1 would move past the end
           soft_endstop_min[X_AXIS] = mechanics.base_min_pos[X_AXIS] + offs;
-          soft_endstop_max[X_AXIS] = min(mechanics.base_max_pos[X_AXIS], dual_max_x - duplicate_hotend_x_offset) + offs;
+          soft_endstop_max[X_AXIS] = min(mechanics.base_max_pos[X_AXIS], dual_max_x - mechanics.duplicate_hotend_x_offset) + offs;
         }
         else {
           // In other modes, T0 can move from X_MIN_POS to X_MAX_POS

--- a/MK4duo/src/mechanics/cartesian_mechanics.cpp
+++ b/MK4duo/src/mechanics/cartesian_mechanics.cpp
@@ -152,37 +152,37 @@
                 active_extruder
               );
             delayed_move_time = 0;
-            active_extruder_parked = false;
+            active_hotend_parked = false;
             #if ENABLED(DEBUG_LEVELING_FEATURE)
-              if (DEBUGGING(LEVELING)) SERIAL_EM("Clear active_extruder_parked");
+              if (DEBUGGING(LEVELING)) SERIAL_EM("Clear active_hotend_parked");
             #endif
             break;
           case DXC_DUPLICATION_MODE:
             if (active_extruder == 0) {
               #if ENABLED(DEBUG_LEVELING_FEATURE)
                 if (DEBUGGING(LEVELING)) {
-                  SERIAL_MV("Set planner X", LOGICAL_X_POSITION(inactive_extruder_x_pos));
-                  SERIAL_EMV(" ... Line to X", current_position[X_AXIS] + duplicate_extruder_x_offset);
+                  SERIAL_MV("Set planner X", LOGICAL_X_POSITION(inactive_hotend_x_pos));
+                  SERIAL_EMV(" ... Line to X", current_position[X_AXIS] + duplicate_hotend_x_offset);
                 }
               #endif
               // move duplicate extruder into correct duplication position.
               set_position_mm(
-                LOGICAL_X_POSITION(inactive_extruder_x_pos),
+                LOGICAL_X_POSITION(inactive_hotend_x_pos),
                 current_position[Y_AXIS],
                 current_position[Z_AXIS],
                 current_position[E_AXIS]
               );
               planner.buffer_line(
-                current_position[X_AXIS] + duplicate_extruder_x_offset,
+                current_position[X_AXIS] + duplicate_hotend_x_offset,
                 current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS],
                 max_feedrate_mm_s[X_AXIS], 1
               );
               sync_plan_position();
               stepper.synchronize();
               hotend_duplication_enabled = true;
-              active_extruder_parked = false;
+              active_hotend_parked = false;
               #if ENABLED(DEBUG_LEVELING_FEATURE)
-                if (DEBUGGING(LEVELING)) SERIAL_EM("Set hotend_duplication_enabled\nClear active_extruder_parked");
+                if (DEBUGGING(LEVELING)) SERIAL_EM("Set hotend_duplication_enabled\nClear active_hotend_parked");
               #endif
             }
             else {
@@ -362,7 +362,7 @@
 
         // This causes the carriage on Dual X to unpark
         #if ENABLED(DUAL_X_CARRIAGE)
-          active_extruder_parked = false;
+          active_hotend_parked = false;
         #endif
 
         do_blocking_move_to_xy(destination[X_AXIS], destination[Y_AXIS]);

--- a/MK4duo/src/mechanics/core_mechanics.cpp
+++ b/MK4duo/src/mechanics/core_mechanics.cpp
@@ -132,37 +132,37 @@
                 active_extruder
               );
             delayed_move_time = 0;
-            active_extruder_parked = false;
+            active_hotend_parked = false;
             #if ENABLED(DEBUG_LEVELING_FEATURE)
-              if (DEBUGGING(LEVELING)) SERIAL_EM("Clear active_extruder_parked");
+              if (DEBUGGING(LEVELING)) SERIAL_EM("Clear active_hotend_parked");
             #endif
             break;
           case DXC_DUPLICATION_MODE:
             if (active_extruder == 0) {
               #if ENABLED(DEBUG_LEVELING_FEATURE)
                 if (DEBUGGING(LEVELING)) {
-                  SERIAL_MV("Set planner X", LOGICAL_X_POSITION(inactive_extruder_x_pos));
-                  SERIAL_EMV(" ... Line to X", current_position[X_AXIS] + duplicate_extruder_x_offset);
+                  SERIAL_MV("Set planner X", LOGICAL_X_POSITION(inactive_hotend_x_pos));
+                  SERIAL_EMV(" ... Line to X", current_position[X_AXIS] + duplicate_hotend_x_offset);
                 }
               #endif
               // move duplicate extruder into correct duplication position.
               set_position_mm(
-                LOGICAL_X_POSITION(inactive_extruder_x_pos),
+                LOGICAL_X_POSITION(inactive_hotend_x_pos),
                 current_position[Y_AXIS],
                 current_position[Z_AXIS],
                 current_position[E_AXIS]
               );
               planner.buffer_line(
-                current_position[X_AXIS] + duplicate_extruder_x_offset,
+                current_position[X_AXIS] + duplicate_hotend_x_offset,
                 current_position[Y_AXIS], current_position[Z_AXIS], current_position[E_AXIS],
                 max_feedrate_mm_s[X_AXIS], 1
               );
               sync_plan_position();
               stepper.synchronize();
               hotend_duplication_enabled = true;
-              active_extruder_parked = false;
+              active_hotend_parked = false;
               #if ENABLED(DEBUG_LEVELING_FEATURE)
-                if (DEBUGGING(LEVELING)) SERIAL_EM("Set hotend_duplication_enabled\nClear active_extruder_parked");
+                if (DEBUGGING(LEVELING)) SERIAL_EM("Set hotend_duplication_enabled\nClear active_hotend_parked");
               #endif
             }
             else {
@@ -342,7 +342,7 @@
 
         // This causes the carriage on Dual X to unpark
         #if ENABLED(DUAL_X_CARRIAGE)
-          active_extruder_parked = false;
+          active_hotend_parked = false;
         #endif
 
         do_blocking_move_to_xy(destination[X_AXIS], destination[Y_AXIS]);

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -165,7 +165,7 @@ class Mechanics {
     /**
      * Workspace Offset
      */
-    #if ENABLED(WORKSPACE_OFFSETS)
+    #if ENABLED(WORKSPACE_OFFSETS) || ENABLED(DUAL_X_CARRIAGE)
       // The distance that XYZ has been offset by G92. Reset by G28.
       float position_shift[XYZ] = { 0 };
 

--- a/MK4duo/src/stepper/stepper.cpp
+++ b/MK4duo/src/stepper/stepper.cpp
@@ -157,7 +157,7 @@ volatile long Stepper::endstops_trigsteps[XYZ];
   #define X_APPLY_STEP(v,Q) { X_STEP_WRITE(v); X2_STEP_WRITE(v); }
 #elif ENABLED(DUAL_X_CARRIAGE)
   #define X_APPLY_DIR(v,ALWAYS) \
-    if (hotend_duplication_enabled || ALWAYS) { \
+    if (mechanics.hotend_duplication_enabled || ALWAYS) { \
       X_DIR_WRITE(v); \
       X2_DIR_WRITE(v); \
     } \
@@ -165,7 +165,7 @@ volatile long Stepper::endstops_trigsteps[XYZ];
       if (TOOL_E_INDEX != 0) X2_DIR_WRITE(v); else X_DIR_WRITE(v); \
     }
   #define X_APPLY_STEP(v,ALWAYS) \
-    if (hotend_duplication_enabled || ALWAYS) { \
+    if (mechanics.hotend_duplication_enabled || ALWAYS) { \
       X_STEP_WRITE(v); \
       X2_STEP_WRITE(v); \
     } \

--- a/MK4duo/src/stepper/stepper_indirection.h
+++ b/MK4duo/src/stepper/stepper_indirection.h
@@ -551,9 +551,9 @@
   #define REV_E_DIR()     { switch(TOOL_DE_INDEX) { case 2: E2_DIR_WRITE( INVERT_E2_DIR); break; case 1: E1_DIR_WRITE( INVERT_E1_DIR); break; case 0: E0_DIR_WRITE( INVERT_E0_DIR); break; } }
 #elif DRIVER_EXTRUDERS > 1
   #if ENABLED(DUAL_X_CARRIAGE)
-    #define E_STEP_WRITE(v) { if(hotend_duplication_enabled) { E0_STEP_WRITE(v); E1_STEP_WRITE(v); } else if(TOOL_DE_INDEX == 0) { E0_STEP_WRITE(v); } else { E1_STEP_WRITE(v); }}
-    #define NORM_E_DIR()    { if(hotend_duplication_enabled) { E0_DIR_WRITE(!INVERT_E0_DIR); E1_DIR_WRITE(!INVERT_E1_DIR); } else if(TOOL_DE_INDEX == 0) { E0_DIR_WRITE(!INVERT_E0_DIR); } else { E1_DIR_WRITE(!INVERT_E1_DIR); }}
-    #define REV_E_DIR()     { if(hotend_duplication_enabled) { E0_DIR_WRITE( INVERT_E0_DIR); E1_DIR_WRITE( INVERT_E1_DIR); } else if(TOOL_DE_INDEX == 0) { E0_DIR_WRITE( INVERT_E0_DIR); } else { E1_DIR_WRITE( INVERT_E1_DIR); }}
+    #define E_STEP_WRITE(v) { if(mechanics.hotend_duplication_enabled) { E0_STEP_WRITE(v); E1_STEP_WRITE(v); } else if(TOOL_DE_INDEX == 0) { E0_STEP_WRITE(v); } else { E1_STEP_WRITE(v); }}
+    #define NORM_E_DIR()    { if(mechanics.hotend_duplication_enabled) { E0_DIR_WRITE(!INVERT_E0_DIR); E1_DIR_WRITE(!INVERT_E1_DIR); } else if(TOOL_DE_INDEX == 0) { E0_DIR_WRITE(!INVERT_E0_DIR); } else { E1_DIR_WRITE(!INVERT_E1_DIR); }}
+    #define REV_E_DIR()     { if(mechanics.hotend_duplication_enabled) { E0_DIR_WRITE( INVERT_E0_DIR); E1_DIR_WRITE( INVERT_E1_DIR); } else if(TOOL_DE_INDEX == 0) { E0_DIR_WRITE( INVERT_E0_DIR); } else { E1_DIR_WRITE( INVERT_E1_DIR); }}
   #else
     #define E_STEP_WRITE(v) { switch(TOOL_DE_INDEX) { case 0: E0_STEP_WRITE(v); break;              case 1: E1_STEP_WRITE(v); break; }}
     #define NORM_E_DIR()    { switch(TOOL_DE_INDEX) { case 0: E0_DIR_WRITE(!INVERT_E0_DIR); break;  case 1: E1_DIR_WRITE(!INVERT_E1_DIR); break; }}


### PR DESCRIPTION
Fix issue n° #133 . I'm not sure if it's ok but now it compiles without errors.
Some variables where used with different names. I'm not sure if that was intentional or not, but the ones with "extruder" instead of "hotend" were not declared anywhere in MK4duo.

I have:

- fixed some "mechanics.VARIABLE" problems due to "mechanics." missing
- replaced **active_extruder_parked** with **active_hotend_parked** (as defined in cartesian_mechanics.h line 54)
- replaced **inactive_extruder_x_pos** with **inactive_hotend_x_pos** (as defined in cartesian_mechanics.h line 49)
- replaced **duplicate_extruder_x_offset** with **duplicate_hotend_x_offset** (as defined in cartesian_mechanics.h line 51)
- replaced **#if ENABLED(WORKSPACE_OFFSETS)** with **#if ENABLED(WORKSPACE_OFFSETS) || ENABLED(DUAL_X_CARRIAGE)** in mechanics.h line 168. (**Is it OK to do this?**)