### PR TITLE
Initial support for SCARA (and more)

### DIFF
--- a/MK4duo/base.h
+++ b/MK4duo/base.h
@@ -48,15 +48,15 @@
   #include "Configuration_Basic.h"
   #include "Configuration_Overall.h"
 
-  #if MECH(CARTESIAN)
+  #if IS_CARTESIAN
     #include "Configuration_Cartesian.h"
   #elif IS_CORE
     #include "Configuration_Core.h"
-  #elif MECH(DELTA)
+  #elif IS_DELTA
     #include "Configuration_Delta.h"
   #elif IS_SCARA
     #include "Configuration_Scara.h"
-  #elif MECH(MUVE3D)
+  #elif IS_MUVE3D
     #include "Configuration_Muve3D.h"
   #endif
 

--- a/MK4duo/src/gcode/motion/g0_g1.h
+++ b/MK4duo/src/gcode/motion/g0_g1.h
@@ -69,7 +69,7 @@ inline void gcode_G0_G1(
     #endif
 
     #if IS_SCARA
-      fast_move ? prepare_uninterpolated_move_to_destination() : mechanics.prepare_move_to_destination();
+      fast_move ? mechanics.prepare_uninterpolated_move_to_destination() : mechanics.prepare_move_to_destination();
     #else
       mechanics.prepare_move_to_destination();
     #endif

--- a/MK4duo/src/gcode/multimode/g7.h
+++ b/MK4duo/src/gcode/multimode/g7.h
@@ -36,25 +36,25 @@
 
     if (parser.seenval('$')) {
       laser.raster_direction = parser.value_int();
-      mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // increment Y axis
+      mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // Increment Y axis
     }
 
     if (parser.seenval('@')) {
       laser.raster_direction = parser.value_int();
       #if ENABLED(LASER_RASTER_MANUAL_Y_FEED)
-        mechanics.destination[X_AXIS] = mechanics.current_position[X_AXIS]; // Dont increment X axis
-        mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS]; // Dont increment Y axis
+        mechanics.destination[X_AXIS] = mechanics.current_position[X_AXIS]; // Don't increment X axis
+        mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS]; // Don't increment Y axis
       #else
         switch(laser.raster_direction) {
           case 0:
           case 1:
           case 4:
-            mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // increment Y axis
+            mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // Increment Y axis
           break;
           case 2:
           case 3:
           case 5:
-            mechanics.destination[X_AXIS] = mechanics.current_position[X_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // increment X axis
+            mechanics.destination[X_AXIS] = mechanics.current_position[X_AXIS] + (laser.raster_mm_per_pulse * laser.raster_aspect_ratio); // Increment X axis
           break;
         }
       #endif
@@ -84,7 +84,7 @@
         mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] + ((laser.raster_mm_per_pulse * laser.raster_num_pixels) * 0.707106);
         if (laser.diagnostics) SERIAL_EM("Negative X Positive Y 45deg Raster Line");
       break;
-      case 5: // Positive X Negarite Y 45deg
+      case 5: // Positive X Negative Y 45deg
         mechanics.destination[X_AXIS] = mechanics.current_position[X_AXIS] + ((laser.raster_mm_per_pulse * laser.raster_num_pixels) * 0.707106);
         mechanics.destination[Y_AXIS] = mechanics.current_position[Y_AXIS] - ((laser.raster_mm_per_pulse * laser.raster_num_pixels) * 0.707106);
         if (laser.diagnostics) SERIAL_EM("Positive X Negative Y 45deg Raster Line");

--- a/MK4duo/src/gcode/scara/m360_m364.h
+++ b/MK4duo/src/gcode/scara/m360_m364.h
@@ -28,18 +28,6 @@
 
 #if MECH(MORGAN_SCARA)
 
-  bool SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b) {
-    if (IsRunning()) {
-      forward_kinematics_SCARA(delta_a, delta_b);
-      mechanics.destination[X_AXIS] = LOGICAL_X_POSITION(mechanics.cartesian_position[X_AXIS]);
-      mechanics.destination[Y_AXIS] = LOGICAL_Y_POSITION(mechanics.cartesian_position[Y_AXIS]);
-      mechanics.destination[Z_AXIS] = mechanics.current_position[Z_AXIS];
-      mechanics.prepare_move_to_destination();
-      return true;
-    }
-    return false;
-  }
-
   #define CODE_M360
   #define CODE_M361
   #define CODE_M362
@@ -51,7 +39,7 @@
    */
   inline bool gcode_M360(void) {
     SERIAL_LM(ECHO, " Cal: Theta 0");
-    return SCARA_move_to_cal(0, 120);
+    return mechanics.move_to_cal_SCARA(0, 120);
   }
 
   /**
@@ -59,7 +47,7 @@
    */
   inline bool gcode_M361(void) {
     SERIAL_LM(ECHO, " Cal: Theta 90");
-    return SCARA_move_to_cal(90, 130);
+    return mechanics.move_to_cal_SCARA(90, 130);
   }
 
   /**
@@ -67,7 +55,7 @@
    */
   inline bool gcode_M362(void) {
     SERIAL_LM(ECHO, " Cal: Psi 0");
-    return SCARA_move_to_cal(60, 180);
+    return mechanics.move_to_cal_SCARA(60, 180);
   }
 
   /**
@@ -75,7 +63,7 @@
    */
   inline bool gcode_M363(void) {
     SERIAL_LM(ECHO, " Cal: Psi 90");
-    return SCARA_move_to_cal(50, 90);
+    return mechanics.move_to_cal_SCARA(50, 90);
   }
 
   /**
@@ -83,7 +71,7 @@
    */
   inline bool gcode_M364(void) {
     SERIAL_LM(ECHO, " Cal: Theta-Psi 90");
-    return SCARA_move_to_cal(45, 135);
+    return mechanics.move_to_cal_SCARA(45, 135);
   }
 
 #endif // MECH(MORGAN_SCARA)

--- a/MK4duo/src/gcode/scara/m360_m364.h
+++ b/MK4duo/src/gcode/scara/m360_m364.h
@@ -39,7 +39,7 @@
    */
   inline bool gcode_M360(void) {
     SERIAL_LM(ECHO, " Cal: Theta 0");
-    return mechanics.move_to_cal_SCARA(0, 120);
+    return mechanics.SCARA_move_to_cal(0, 120);
   }
 
   /**
@@ -47,7 +47,7 @@
    */
   inline bool gcode_M361(void) {
     SERIAL_LM(ECHO, " Cal: Theta 90");
-    return mechanics.move_to_cal_SCARA(90, 130);
+    return mechanics.SCARA_move_to_cal(90, 130);
   }
 
   /**
@@ -55,7 +55,7 @@
    */
   inline bool gcode_M362(void) {
     SERIAL_LM(ECHO, " Cal: Psi 0");
-    return mechanics.move_to_cal_SCARA(60, 180);
+    return mechanics.SCARA_move_to_cal(60, 180);
   }
 
   /**
@@ -63,7 +63,7 @@
    */
   inline bool gcode_M363(void) {
     SERIAL_LM(ECHO, " Cal: Psi 90");
-    return mechanics.move_to_cal_SCARA(50, 90);
+    return mechanics.SCARA_move_to_cal(50, 90);
   }
 
   /**
@@ -71,7 +71,7 @@
    */
   inline bool gcode_M364(void) {
     SERIAL_LM(ECHO, " Cal: Theta-Psi 90");
-    return mechanics.move_to_cal_SCARA(45, 135);
+    return mechanics.SCARA_move_to_cal(45, 135);
   }
 
 #endif // MECH(MORGAN_SCARA)

--- a/MK4duo/src/macros.h
+++ b/MK4duo/src/macros.h
@@ -55,13 +55,14 @@
 #define IS_SCARA      (MECH(MORGAN_SCARA) || MECH(MAKERARM_SCARA))
 #define IS_DELTA      (MECH(DELTA))
 #define IS_KINEMATIC  (IS_DELTA || IS_SCARA)
+#define IS_MUVE3D     (MECH(MUVE3D))
 
 #define CORE_IS_XY    (MECH(COREXY) || MECH(COREYX))
 #define CORE_IS_XZ    (MECH(COREXZ) || MECH(COREZX))
 #define CORE_IS_YZ    (MECH(COREYZ) || MECH(COREZY))
 #define IS_CORE       (CORE_IS_XY || CORE_IS_XZ || CORE_IS_YZ)
 
-#define IS_CARTESIAN  (!IS_KINEMATIC && !IS_CORE)
+#define IS_CARTESIAN  (MECH(CARTESIAN))
 /********************************************************************/
 
 // Compiler warning on unused varable.

--- a/MK4duo/src/mechanics/cartesian_mechanics.cpp
+++ b/MK4duo/src/mechanics/cartesian_mechanics.cpp
@@ -276,34 +276,15 @@
    * Prepare a single move and get ready for the next one
    * If Mesh Bed Leveling is enabled, perform a mesh move.
    */
-  void Cartesian_Mechanics::prepare_move_to_destination() {
-
-    endstops.clamp_to_software_endstops(destination);
-    commands.refresh_cmd_timeout();
-
-    #if ENABLED(PREVENT_COLD_EXTRUSION)
-
-      if (!DEBUGGING(DRYRUN)) {
-        if (destination[E_AXIS] != current_position[E_AXIS]) {
-          if (thermalManager.tooColdToExtrude(tools.active_extruder))
-            current_position[E_AXIS] = destination[E_AXIS];
-          #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
-            if (destination[E_AXIS] - current_position[E_AXIS] > EXTRUDE_MAXLENGTH) {
-              current_position[E_AXIS] = destination[E_AXIS];
-              SERIAL_LM(ER, MSG_ERR_LONG_EXTRUDE_STOP);
-            }
-          #endif
-        }
-      }
-    #endif
-
+  bool Cartesian_Mechanics::prepare_move_to_destination_mech_specific() {
     #if ENABLED(DUAL_X_CARRIAGE)
-      if (prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()) return;
+      if (prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()) return true;
     #else
-      if (prepare_move_to_destination_cartesian()) return;
+      if (prepare_move_to_destination_cartesian()) return true;
     #endif
 
     set_current_to_destination();
+    return false;
   }
 
   #if ENABLED(DUAL_X_CARRIAGE)

--- a/MK4duo/src/mechanics/cartesian_mechanics.h
+++ b/MK4duo/src/mechanics/cartesian_mechanics.h
@@ -83,7 +83,7 @@
        * Prepare a single move and get ready for the next one
        * If Mesh Bed Leveling is enabled, perform a mesh move.
        */
-      void prepare_move_to_destination();
+      bool prepare_move_to_destination_mech_specific();
 
       /**
        * Set an axis' current position to its home position (after homing).

--- a/MK4duo/src/mechanics/core_mechanics.cpp
+++ b/MK4duo/src/mechanics/core_mechanics.cpp
@@ -256,34 +256,16 @@
    * Prepare a single move and get ready for the next one
    * If Mesh Bed Leveling is enabled, perform a mesh move.
    */
-  void Core_Mechanics::prepare_move_to_destination() {
-
-    endstops.clamp_to_software_endstops(destination);
-    commands.refresh_cmd_timeout();
-
-    #if ENABLED(PREVENT_COLD_EXTRUSION)
-
-      if (!DEBUGGING(DRYRUN)) {
-        if (destination[E_AXIS] != current_position[E_AXIS]) {
-          if (thermalManager.tooColdToExtrude(tools.active_extruder))
-            current_position[E_AXIS] = destination[E_AXIS];
-          #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
-            if (destination[E_AXIS] - current_position[E_AXIS] > EXTRUDE_MAXLENGTH) {
-              current_position[E_AXIS] = destination[E_AXIS];
-              SERIAL_LM(ER, MSG_ERR_LONG_EXTRUDE_STOP);
-            }
-          #endif
-        }
-      }
-    #endif
+  bool Core_Mechanics::prepare_move_to_destination_mech_specific() {
 
     #if ENABLED(DUAL_X_CARRIAGE)
-      if (prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()) return;
+      if (prepare_move_to_destination_dualx() || prepare_move_to_destination_cartesian()) return true;
     #else
-      if (prepare_move_to_destination_cartesian()) return;
+      if (prepare_move_to_destination_cartesian()) return true;
     #endif
 
     set_current_to_destination();
+    return false;
   }
 
   #if ENABLED(DUAL_X_CARRIAGE)

--- a/MK4duo/src/mechanics/core_mechanics.h
+++ b/MK4duo/src/mechanics/core_mechanics.h
@@ -83,7 +83,7 @@
        * Prepare a single move and get ready for the next one
        * If Mesh Bed Leveling is enabled, perform a mesh move.
        */
-      void prepare_move_to_destination();
+      bool prepare_move_to_destination_mech_specific();
 
       /**
        * Set an axis' current position to its home position (after homing).

--- a/MK4duo/src/mechanics/delta_mechanics.h
+++ b/MK4duo/src/mechanics/delta_mechanics.h
@@ -87,7 +87,7 @@
        * This calls buffer_line several times, adding
        * small incremental moves for DELTA.
        */
-      void prepare_move_to_destination();
+      bool prepare_move_to_destination_mech_specific();
 
       /**
        *  Plan a move to (X, Y, Z) and set the current_position

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -243,6 +243,23 @@ class Mechanics {
     FORCE_INLINE void line_to_destination() { line_to_destination(feedrate_mm_s); }
 
     /**
+     * Prepare a single move and get ready for the next one
+     *
+     * This may result in several calls to planner.buffer_line to
+     * do smaller moves for DELTA, SCARA, mesh moves, etc.
+     */
+    void Mechanics::prepare_move_to_destination();
+
+    /**
+     * Prepare a single move and get ready for the next one
+     *
+     * This function is specific to the mechanics of the machine,
+     * therefore is pure virtual and MUST be implemented in every
+     * Mechanics subclass!
+     */
+    virtual bool Mechanics::prepare_move_to_destination_mech_specific() = 0;
+
+    /**
      * Plan a move to (X, Y, Z) and set the current_position
      * The final current_position may not be the one that was requested
      */
@@ -332,8 +349,8 @@ class Mechanics {
 #elif IS_DELTA
   #include "delta_mechanics.h"
 #elif IS_SCARA
-  #error "This version not supoorted scara for now, please use old version"
-  //#include "scara_mechanism.h"
+  #error "This version does not support SCARA mechanics as for now, please use an older version of the firmware!"
+  //#include "scara_mechanics.h"
 #endif
 
 #endif /* _MECHANICS_H_ */

--- a/MK4duo/src/mechanics/scara_mechanics.cpp
+++ b/MK4duo/src/mechanics/scara_mechanics.cpp
@@ -1,0 +1,250 @@
+/**
+ * MK4duo Firmware for 3D Printer, Laser and CNC
+ *
+ * Based on Marlin, Sprinter and grbl
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ * Copyright (C) 2013 Alberto Cotronei @MagoKimbra
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * scara_mechanics.cpp
+ *
+ * Copyright (C) 2016 Alberto Cotronei @MagoKimbra
+ */
+
+#include "../../base.h"
+#include "scara_mechanics.h"
+
+#if IS_SCARA
+
+  Scara_Mechanics mechanics;
+
+  void Scara_Mechanics::Init() {
+      //TODO!!!
+
+  }
+
+ /**
+ * Prepare a linear move in a SCARA setup.
+ *
+ * This calls planner.buffer_line several times, adding
+ * small incremental moves for SCARA.
+ */
+ bool Scara_Mechanics::prepare_move_to_destination_mech_specific() {
+
+  // Get the top feedrate of the move in the XY plane
+  const float _feedrate_mm_s = MMS_SCALED(feedrate_mm_s);
+
+  // If the move is only in Z/E don't split up the move
+  if (destination[X_AXIS] == current_position[X_AXIS] && destination[Y_AXIS] == current_position[Y_AXIS]) {
+    planner.buffer_line_kinematic(destination, _feedrate_mm_s, active_extruder);
+    return false;
+  }
+
+  // Fail if attempting move outside printable radius
+  if (!position_is_reachable_xy(destination[X_AXIS], destination[Y_AXIS])) return true;
+
+  // Get the cartesian distances moved in XYZE
+  const float difference[XYZE] = {
+    destination[X_AXIS] - current_position[X_AXIS],
+    destination[Y_AXIS] - current_position[Y_AXIS],
+    destination[Z_AXIS] - current_position[Z_AXIS],
+    destination[E_AXIS] - current_position[E_AXIS]
+  };
+
+  // Get the linear distance in XYZ
+  float cartesian_mm = SQRT(sq(difference[X_AXIS]) + sq(difference[Y_AXIS]) + sq(difference[Z_AXIS]));
+
+  // If the move is very short, check the E move distance
+  if (UNEAR_ZERO(cartesian_mm)) cartesian_mm = FABS(difference[E_AXIS]);
+
+  // No E move either? Game over.
+  if (UNEAR_ZERO(cartesian_mm)) return true;
+
+  // Minimum number of seconds to move the given distance
+  const float seconds = cartesian_mm / _feedrate_mm_s;
+
+  // The number of segments-per-second times the duration
+  // gives the number of segments
+  uint16_t segments = delta_segments_per_second * seconds;
+
+  // For SCARA minimum segment size is 0.25mm
+  NOMORE(segments, cartesian_mm * 4);
+
+  // At least one segment is required
+  NOLESS(segments, 1);
+
+  // The approximate length of each segment
+  const float inv_segments = 1.0 / float(segments),
+              segment_distance[XYZE] = {
+                difference[X_AXIS] * inv_segments,
+                difference[Y_AXIS] * inv_segments,
+                difference[Z_AXIS] * inv_segments,
+                difference[E_AXIS] * inv_segments
+              };
+
+  // SERIAL_ECHOPAIR("mm=", cartesian_mm);
+  // SERIAL_ECHOPAIR(" seconds=", seconds);
+  // SERIAL_ECHOLNPAIR(" segments=", segments);
+
+  #if ENABLED(SCARA_FEEDRATE_SCALING)
+    // SCARA needs to scale the feed rate from mm/s to degrees/s
+    const float inv_segment_length = min(10.0, float(segments) / cartesian_mm), // 1/mm/segs
+                feed_factor = inv_segment_length * _feedrate_mm_s;
+    float oldA = stepper.get_axis_position_degrees(A_AXIS),
+          oldB = stepper.get_axis_position_degrees(B_AXIS);
+  #endif
+
+  // Get the logical current position as starting point
+  float logical[XYZE];
+  COPY(logical, current_position);
+
+  // Drop one segment so the last move is to the exact target.
+  // If there's only 1 segment, loops will be skipped entirely.
+  --segments;
+
+  // Calculate and execute the segments
+  for (uint16_t s = segments + 1; --s;) {
+    LOOP_XYZE(i) logical[i] += segment_distance[i];
+    inverse_kinematics(logical);
+
+    ADJUST_DELTA(logical); // Adjust Z if bed leveling is enabled
+
+    #if ENABLED(SCARA_FEEDRATE_SCALING)
+      // For SCARA scale the feed rate from mm/s to degrees/s
+      // Use ratio between the length of the move and the larger angle change
+      const float adiff = abs(delta[A_AXIS] - oldA),
+                  bdiff = abs(delta[B_AXIS] - oldB);
+      planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], logical[E_AXIS], max(adiff, bdiff) * feed_factor, active_extruder);
+      oldA = delta[A_AXIS];
+      oldB = delta[B_AXIS];
+    #else
+      planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], logical[E_AXIS], _feedrate_mm_s, active_extruder);
+    #endif
+  }
+
+  // Since segment_distance is only approximate,
+  // the final move must be to the exact destination.
+
+  #if ENABLED(SCARA_FEEDRATE_SCALING)
+    // For SCARA scale the feed rate from mm/s to degrees/s
+    // With segments > 1 length is 1 segment, otherwise total length
+    inverse_kinematics(ltarget);
+    ADJUST_DELTA(ltarget);
+    const float adiff = abs(delta[A_AXIS] - oldA),
+                bdiff = abs(delta[B_AXIS] - oldB);
+    planner.buffer_line(delta[A_AXIS], delta[B_AXIS], delta[C_AXIS], logical[E_AXIS], max(adiff, bdiff) * feed_factor, active_extruder);
+  #else
+    planner.buffer_line_kinematic(ltarget, _feedrate_mm_s, active_extruder);
+  #endif
+
+  return false;
+}
+
+bool Scara_Mechanics::move_to_cal_SCARA(uint8_t delta_a, uint8_t delta_b) {
+  if (printer.IsRunning()) {
+    this.forward_kinematics_SCARA(delta_a, delta_b);
+    this.destination[X_AXIS] = LOGICAL_X_POSITION(this.cartesian_position[X_AXIS]);
+    this.destination[Y_AXIS] = LOGICAL_Y_POSITION(this.cartesian_position[Y_AXIS]);
+    this.destination[Z_AXIS] = this.current_position[Z_AXIS];
+    this.prepare_move_to_destination();
+    return true;
+  }
+  return false;
+}
+
+#if ENABLED(MORGAN_SCARA)
+
+  /**
+   * Morgan SCARA Forward Kinematics. Results in cartes[].
+   * Maths and first version by QHARLEY.
+   * Integrated into Marlin and slightly restructured by Joachim Cerny.
+   */
+  void Scara_Mechanics::forward_kinematics_SCARA(const float &a, const float &b) {
+
+    float a_sin = sin(RADIANS(a)) * L1,
+          a_cos = cos(RADIANS(a)) * L1,
+          b_sin = sin(RADIANS(b)) * L2,
+          b_cos = cos(RADIANS(b)) * L2;
+
+    cartes[X_AXIS] = a_cos + b_cos + SCARA_OFFSET_X;  //theta
+    cartes[Y_AXIS] = a_sin + b_sin + SCARA_OFFSET_Y;  //theta+phi
+
+    /*
+      SERIAL_ECHOPAIR("SCARA FK Angle a=", a);
+      SERIAL_ECHOPAIR(" b=", b);
+      SERIAL_ECHOPAIR(" a_sin=", a_sin);
+      SERIAL_ECHOPAIR(" a_cos=", a_cos);
+      SERIAL_ECHOPAIR(" b_sin=", b_sin);
+      SERIAL_ECHOLNPAIR(" b_cos=", b_cos);
+      SERIAL_ECHOPAIR(" cartes[X_AXIS]=", cartes[X_AXIS]);
+      SERIAL_ECHOLNPAIR(" cartes[Y_AXIS]=", cartes[Y_AXIS]);
+    //*/
+  }
+
+  /**
+   * Morgan SCARA Inverse Kinematics. Results in delta[].
+   *
+   * See http://forums.reprap.org/read.php?185,283327
+   *
+   * Maths and first version by QHARLEY.
+   * Integrated into Marlin and slightly restructured by Joachim Cerny.
+   */
+  void Scara_Mechanics::inverse_kinematics(const float logical[XYZ]) {
+
+    static float C2, S2, SK1, SK2, THETA, PSI;
+
+    float sx = RAW_X_POSITION(logical[X_AXIS]) - SCARA_OFFSET_X,  // Translate SCARA to standard X Y
+          sy = RAW_Y_POSITION(logical[Y_AXIS]) - SCARA_OFFSET_Y;  // With scaling factor.
+
+    if (L1 == L2)
+      C2 = HYPOT2(sx, sy) / L1_2_2 - 1;
+    else
+      C2 = (HYPOT2(sx, sy) - (L1_2 + L2_2)) / (2.0 * L1 * L2);
+
+    S2 = SQRT(1 - sq(C2));
+
+    // Unrotated Arm1 plus rotated Arm2 gives the distance from Center to End
+    SK1 = L1 + L2 * C2;
+
+    // Rotated Arm2 gives the distance from Arm1 to Arm2
+    SK2 = L2 * S2;
+
+    // Angle of Arm1 is the difference between Center-to-End angle and the Center-to-Elbow
+    THETA = ATAN2(SK1, SK2) - ATAN2(sx, sy);
+
+    // Angle of Arm2
+    PSI = ATAN2(S2, C2);
+
+    delta[A_AXIS] = DEGREES(THETA);        // theta is support arm angle
+    delta[B_AXIS] = DEGREES(THETA + PSI);  // equal to sub arm angle (inverted motor)
+    delta[C_AXIS] = logical[Z_AXIS];
+
+    /*
+      DEBUG_POS("SCARA IK", logical);
+      DEBUG_POS("SCARA IK", delta);
+      SERIAL_ECHOPAIR("  SCARA (x,y) ", sx);
+      SERIAL_ECHOPAIR(",", sy);
+      SERIAL_ECHOPAIR(" C2=", C2);
+      SERIAL_ECHOPAIR(" S2=", S2);
+      SERIAL_ECHOPAIR(" Theta=", THETA);
+      SERIAL_ECHOLNPAIR(" Phi=", PHI);
+    //*/
+  }
+
+#endif // MORGAN_SCARA
+#endif // IS_SCARA

--- a/MK4duo/src/mechanics/scara_mechanics.cpp
+++ b/MK4duo/src/mechanics/scara_mechanics.cpp
@@ -155,6 +155,27 @@
     return false;
   }
 
+ /**
+   * Calculate delta, start a line, and set current_position to destination
+   */
+  void Scara_Mechanics::prepare_uninterpolated_move_to_destination(const float fr_mm_s=0.0) {
+    #if ENABLED(DEBUG_LEVELING_FEATURE)
+      if (DEBUGGING(LEVELING)) DEBUG_POS("prepare_uninterpolated_move_to_destination", destination);
+    #endif
+
+    commands.refresh_cmd_timeout();
+
+    if ( current_position[X_AXIS] == destination[X_AXIS]
+      && current_position[Y_AXIS] == destination[Y_AXIS]
+      && current_position[Z_AXIS] == destination[Z_AXIS]
+      && current_position[E_AXIS] == destination[E_AXIS]
+    ) return;
+
+    planner.buffer_line_kinematic(destination, MMS_SCALED(fr_mm_s ? fr_mm_s : feedrate_mm_s), active_extruder);
+
+    set_current_to_destination();
+  }
+ 
 #if ENABLED(MORGAN_SCARA)
 
   bool Scara_Mechanics::SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b) {

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -1,0 +1,71 @@
+/**
+ * MK4duo Firmware for 3D Printer, Laser and CNC
+ *
+ * Based on Marlin, Sprinter and grbl
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ * Copyright (C) 2013 Alberto Cotronei @MagoKimbra
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * scara_mechanics.h
+ *
+ * Copyright (C) 2016 Alberto Cotronei @MagoKimbra
+ */
+
+#ifndef _SCARA_MECHANICS_H_
+#define _SCARA_MECHANICS_H_
+
+#if IS_SCARA
+
+  class Scara_Mechanics : public Mechanics {
+
+    public: /** Constructor */
+
+      Scara_Mechanics() {};
+
+    public: /** Public Parameters */
+      
+
+    public: /** Public Function */
+
+      /**
+       * Initialize Scara parameters
+       */
+      void Init();
+
+      /**
+       * Prepare a linear move in a SCARA setup.
+       *
+       * This calls planner.buffer_line several times, adding
+       * small incremental moves for SCARA.
+       */
+      bool prepare_move_to_destination_mech_specific();
+
+    private: /** Private Parameters */
+
+     
+
+    private: /** Private Function */
+      
+     
+  };
+
+  extern Scara_Mechanics mechanics;
+
+#endif // IS_SCARA
+
+#endif /* _SCARA_MECHANICS_H_ */

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -55,6 +55,11 @@
        */
       bool prepare_move_to_destination_mech_specific();
 
+      #if MECH(MORGAN_SCARA)
+        bool SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b);
+        void forward_kinematics_SCARA(const float &a, const float &b);
+      #endif
+
     private: /** Private Parameters */
 
      

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -55,6 +55,11 @@
        */
       bool prepare_move_to_destination_mech_specific();
 
+      /**
+       * Calculate delta, start a line, and set current_position to destination
+       */
+      void prepare_uninterpolated_move_to_destination(const float fr_mm_s=0.0);
+
       #if MECH(MORGAN_SCARA)
         bool SCARA_move_to_cal(uint8_t delta_a, uint8_t delta_b);
         void forward_kinematics_SCARA(const float &a, const float &b);


### PR DESCRIPTION
Buon ferragosto, Mago :)

Added **initial** support for SCARA mechanics. I've added only some of the SCARA specific functions, **more are missing**.

Fixed and cleared some gcode functions (g0_g1, g7, m360_m364).

Since every `prepare_move_to_destination()` started in the same way, I've created a `prepare_move_to_destination()` in `Mechanics` with the code common to every mechanics. When the mechanics specific code needs to be executed, `prepare_move_to_destination_mech_specific()` is called. That is a pure virtual function of `Mechanics`: is virtual but is not implemented in `Mechanics` (and so it doesn't need to be `override`). This way `Mechanics` automatically becomes an abstract class (**as it should be**): this forces the compiler to check that a `Mechanics` object is NEVER created. Subclasses are also forced to implement that abstract method in order to have the possibility of being instantiated (**as it should be**).