### PR TITLE
Little update and added Ramps4Due displays

### DIFF
--- a/MK4duo/src/boards/1433.h
+++ b/MK4duo/src/boards/1433.h
@@ -168,4 +168,167 @@
 #endif
 //@@@
 
+//###IF_BLOCKS
+#if ENABLED(ULTRA_LCD)
+
+  #if ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+    #define LCD_PINS_RS         49 // CS chip select /SS chip slave select
+    #define LCD_PINS_ENABLE     51 // SID (MOSI)
+    #define LCD_PINS_D4         52 // SCK (CLK) clock
+  #elif ENABLED(NEWPANEL) && ENABLED(PANEL_ONE)
+    #define LCD_PINS_RS         40
+    #define LCD_PINS_ENABLE     42
+    #define LCD_PINS_D4         65
+    #define LCD_PINS_D5         66
+    #define LCD_PINS_D6         44
+    #define LCD_PINS_D7         64
+  #else
+    #define LCD_PINS_RS         16
+    #define LCD_PINS_ENABLE     17
+    #define LCD_PINS_D4         23
+    #define LCD_PINS_D5         25
+    #define LCD_PINS_D6         27
+    #define LCD_PINS_D7         29
+    #if DISABLED(NEWPANEL)
+      #define BEEPER_PIN        33
+      // Buttons are attached to a shift register
+      // Not wired yet
+      //#define SHIFT_CLK 38
+      //#define SHIFT_LD 42
+      //#define SHIFT_OUT 40
+      //#define SHIFT_EN 17
+    #endif
+  #endif
+
+  #if ENABLED(NEWPANEL)
+
+    #if ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER)
+
+      #define BEEPER_PIN        37
+
+      #define BTN_EN1           31
+      #define BTN_EN2           33
+      #define BTN_ENC           35
+
+      #define SD_DETECT_PIN     49
+      #define KILL_PIN          41
+
+      #if ENABLED(BQ_LCD_SMART_CONTROLLER)
+        #define LCD_BACKLIGHT_PIN 39
+      #endif
+
+    #elif ENABLED(REPRAPWORLD_GRAPHICAL_LCD)
+
+      #define BTN_EN1           64
+      #define BTN_EN2           59
+      #define BTN_ENC           63
+      #define SD_DETECT_PIN     42
+
+    #elif ENABLED(LCD_I2C_PANELOLU2)
+
+      #define BTN_EN1           47
+      #define BTN_EN2           43
+      #define BTN_ENC           32
+      #define LCD_SDSS          53
+      #define SD_DETECT_PIN     -1
+      #define KILL_PIN          41
+
+    #elif ENABLED(LCD_I2C_VIKI)
+
+      #define BTN_EN1           22 // http://files.panucatt.com/datasheets/viki_wiring_diagram.pdf explains 40/42.
+      #define BTN_EN2            7 // 22/7 are unused on RAMPS_14. 22 is unused and 7 the SERVO0_PIN on RAMPS_13.
+
+      #define BTN_ENC           -1
+      #define LCD_SDSS          53
+      #define SD_DETECT_PIN     49
+
+    #elif ENABLED(VIKI2) || ENABLED(miniVIKI)
+
+      #define BEEPER_PIN        33
+
+      // Pins for DOGM SPI LCD Support
+      #define DOGLCD_A0         44
+      #define DOGLCD_CS         45
+      #define LCD_SCREEN_ROT_180
+
+      #define BTN_EN1           22
+      #define BTN_EN2            7
+      #define BTN_ENC           39
+
+      #define SDSS              53
+      #define SD_DETECT_PIN     -1 // Pin 49 for display sd interface, 72 for easy adapter board
+
+      #define KILL_PIN          31
+
+      #define STAT_LED_RED_PIN  32
+      #define STAT_LED_BLUE_PIN 35
+
+    #elif ENABLED(ELB_FULL_GRAPHIC_CONTROLLER)
+      #define BTN_EN1           35
+      #define BTN_EN2           37
+      #define BTN_ENC           31
+      #define SD_DETECT_PIN     49
+      #define LCD_SDSS          53
+      #define KILL_PIN          41
+      #define BEEPER_PIN        23
+      #define DOGLCD_CS         29
+      #define DOGLCD_A0         27
+      #define LCD_BACKLIGHT_PIN 33
+    #elif ENABLED(MINIPANEL)
+      #define BEEPER_PIN        42
+      // Pins for DOGM SPI LCD Support
+      #define DOGLCD_A0         44
+      #define DOGLCD_CS         66
+      #define LCD_BACKLIGHT_PIN 65 // backlight LED on A11/D65
+      #define SDSS              53
+
+      #define KILL_PIN          64
+      // GLCD features
+      //#define LCD_CONTRAST   190
+      // Uncomment screen orientation
+      //#define LCD_SCREEN_ROT_90
+      //#define LCD_SCREEN_ROT_180
+      //#define LCD_SCREEN_ROT_270
+      // The encoder and click button
+      #define BTN_EN1           40
+      #define BTN_EN2           63
+      #define BTN_ENC           59
+      // not connected to a pin
+      #define SD_DETECT_PIN     49
+
+    #else
+
+      // Beeper on AUX-4
+      #define BEEPER_PIN        33
+
+      // buttons are directly attached using AUX-2
+      #if ENABLED(REPRAPWORLD_KEYPAD)
+        #define BTN_EN1         64
+        #define BTN_EN2         59
+        #define BTN_ENC         63
+        #define SHIFT_OUT       40
+        #define SHIFT_CLK       44
+        #define SHIFT_LD        42
+      #elif ENABLED(PANEL_ONE)
+        #define BTN_EN1         59 // AUX2 PIN 3
+        #define BTN_EN2         63 // AUX2 PIN 4
+        #define BTN_ENC         49 // AUX3 PIN 7
+      #else
+        #define BTN_EN1         37
+        #define BTN_EN2         35
+        #define BTN_ENC         31
+      #endif
+
+      #if ENABLED(G3D_PANEL)
+        #define SD_DETECT_PIN   49
+        #define KILL_PIN        41
+      #else
+        //#define SD_DETECT_PIN -1 // Ramps doesn't use this
+      #endif
+
+    #endif
+  #endif // NEWPANEL
+
+#endif // ULTRA_LCD
+//@@@
 

--- a/contributing.md
+++ b/contributing.md
@@ -11,7 +11,11 @@ The work needed to clean-up **MK4duo** code isn't finished yet: this is the reas
 _Remember: a cleaner code is a **more robust** code!_
 
 ### TODO tags
-If you feel that your contribution still needs some work, or that there are sections in the firmware code that need to be fixed/completed, please add a comment in the right place starting with the **TODO** tag, like this one: `// TODO: we should implement counterclockwise functionality for this function`. **TODO** tags can be pretty useful: it's possible, for example, to extract the complete list of TODOs simply by running a command like `git grep "TODO"` in the repository folder.
+If you feel that your contribution still needs some work, or that there are sections in the firmware code that need to be fixed/completed, please add a comment in the right place starting with the **TODO** tag, like this one:
+
+`// TODO: we should implement counterclockwise functionality for this function`.
+
+**TODO** tags can be pretty useful: it's possible, for example, to extract the complete list of TODOs simply by running a command like `git grep "TODO"` in the repository folder.
 
 ### Memory consumption and coding standards
 Try to minimize the number of variables used and to define them inside the function scope: this way, when the function will return, that memory will be freed. For coding standards you can refer to the good _Marlin_ documentation written by [thinkyhead](https://github.com/thinkyhead): [Coding Standards](https://github.com/MarlinFirmware/MarlinDocumentation/blob/master/_development/coding_standards.md).

--- a/contributing.md
+++ b/contributing.md
@@ -10,6 +10,9 @@ The work needed to clean-up **MK4duo** code isn't finished yet: this is the reas
 
 _Remember: a cleaner code is a **more robust** code!_
 
+### TODO tags
+If you feel that your contribution still needs some work, or that there are sections in the firmware code that need to be fixed/completed, please add a comment in the right place starting with the **TODO** tag, like this one: `// TODO: we should implement counterclockwise functionality for this function`. **TODO** tags can be pretty useful: it's possible, for example, to extract the complete list of TODOs simply by running a command like `git grep "TODO"` in the repository folder.
+
 ### Memory consumption and coding standards
 Try to minimize the number of variables used and to define them inside the function scope: this way, when the function will return, that memory will be freed. For coding standards you can refer to the good _Marlin_ documentation written by [thinkyhead](https://github.com/thinkyhead): [Coding Standards](https://github.com/MarlinFirmware/MarlinDocumentation/blob/master/_development/coding_standards.md).
 

--- a/issue_template.md
+++ b/issue_template.md
@@ -6,6 +6,15 @@ Try to give us every information you can: sometimes **big** problems are caused 
 ### Issue description
 Tell us what happened: don't miss any valuable detail, try to be clear and concise, don't use UPPERCASE or abbreviations which can make understanding what you wrote quite difficult.
 
+### Compile errors - IMPORTANT
+If you have problems compiling MK4duo, report here the error messages Arduino IDE gives you.
+
+Before posting this issue, however, take a long breath and check this two things:
+1. If you're not using the latest version of Arduino IDE, please retry compiling with the latest one. Sometimes errors are caused by old versions of the compiler and not by MK4duo code.
+2. Read carefully every error message you get: if an error starts with `DEPENDENCY ERROR: _something wrong!_`, well, that's not a compiling error! **DO NOT POST DEPENDENCY ERRORS**, please! Actually, they are self-explanatory messages which tell you what configuration option was set badly. You just have to go back and fix your configuration.
+
+**Dependency errors are not MK4duo errors, are YOUR errors!** If you also get other types of error, please be sure to have fixed dependency errors **before** posting this issue!
+
 ### Firmware version
 Always remember to write what version of MK4duo you're using
 


### PR DESCRIPTION
Updated issue_template.md and contributing.md

Copied the display settings of the Ramps4Due board from Marlin (actually they are the same pins as Ramps): these have to be controlled! This is related to #127 and #199 issues.