### PR TITLE
Fix warnings, errors and COLOR_MIXING_EXTRUDER full support

### DIFF
--- a/MK4duo/src/HAL/HAL_AVR/HardwareSerial.cpp
+++ b/MK4duo/src/HAL/HAL_AVR/HardwareSerial.cpp
@@ -136,7 +136,7 @@
                 printer.kill(PSTR(MSG_KILLED));
                 break;
               case state_M410:
-                quickstop_stepper();
+                printer.quickstop_stepper();
                 break;
               default:
                 break;

--- a/MK4duo/src/commands/commands.cpp
+++ b/MK4duo/src/commands/commands.cpp
@@ -560,7 +560,7 @@ void Commands::process_next_command() {
   switch (parser.command_letter) {
 
     case 'G': {
-      const int code_num = parser.codenum;
+      const uint16_t code_num = parser.codenum;
       G_CODE_TYPE start   = 0,
                   middle  = 0,
                   end     = COUNT(GCode_Table) - 1;
@@ -585,7 +585,7 @@ void Commands::process_next_command() {
     break;
 
     case 'M': {
-      const int code_num = parser.codenum;
+      const uint16_t code_num = parser.codenum;
       M_CODE_TYPE start   = 0,
                   middle  = 0,
                   end     = COUNT(MCode_Table) - 1;

--- a/MK4duo/src/commands/parser.cpp
+++ b/MK4duo/src/commands/parser.cpp
@@ -41,7 +41,7 @@ char *GCodeParser::command_ptr,
      *GCodeParser::string_arg,
      *GCodeParser::value_ptr;
 char  GCodeParser::command_letter;
-int   GCodeParser::codenum;
+uint16_t   GCodeParser::codenum;
 
 #if USE_GCODE_SUBCODES
   uint8_t GCodeParser::subcode;

--- a/MK4duo/src/commands/parser.h
+++ b/MK4duo/src/commands/parser.h
@@ -73,7 +73,7 @@ class GCodeParser {
                 *string_arg;                // string of command line
 
     static char command_letter;             // G, M, or T
-    static int codenum;                     // 123
+    static uint16_t codenum;                // 123
     #if USE_GCODE_SUBCODES
       static uint8_t subcode;               // .1
     #endif

--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -719,7 +719,7 @@ void EEPROM::Postprocess() {
       #if HEATER_USES_AD595
         EEPROM_READ(thermalManager.ad595_offset);
         EEPROM_READ(thermalManager.ad595_gain);
-        for (int8_t h = 0; h < HOTENDS; h++)
+        for (uint8_t h = 0; h < HOTENDS; h++)
           if (thermalManager.ad595_gain[h] == 0) thermalManager.ad595_gain[h] == TEMP_SENSOR_AD595_GAIN;
       #endif
 
@@ -756,7 +756,7 @@ void EEPROM::Postprocess() {
       EEPROM_READ(lcd_preheat_fan_speed);
 
       #if ENABLED(PIDTEMP)
-        for (int8_t h = 0; h < HOTENDS; h++) {
+        for (uint8_t h = 0; h < HOTENDS; h++) {
           EEPROM_READ(PID_PARAM(Kp, h));
           EEPROM_READ(PID_PARAM(Ki, h));
           EEPROM_READ(PID_PARAM(Kd, h));
@@ -811,7 +811,7 @@ void EEPROM::Postprocess() {
 
       EEPROM_READ(tools.volumetric_enabled);
 
-      for (int8_t e = 0; e < EXTRUDERS; e++)
+      for (uint8_t e = 0; e < EXTRUDERS; e++)
         EEPROM_READ(tools.filament_size[e]);
 
       #if ENABLED(IDLE_OOZING_PREVENT)
@@ -1188,7 +1188,7 @@ void EEPROM::Factory_Settings() {
     #endif
     SERIAL_EOL();
     #if EXTRUDERS > 1
-      for (int8_t i = 0; i < EXTRUDERS; i++) {
+      for (uint8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M92 T", i);
         SERIAL_EMV(" E", VOLUMETRIC_UNIT(mechanics.axis_steps_per_mm[E_AXIS + i]), 3);
       }
@@ -1203,7 +1203,7 @@ void EEPROM::Factory_Settings() {
     #endif
     SERIAL_EOL();
     #if EXTRUDERS > 1
-      for (int8_t i = 0; i < EXTRUDERS; i++) {
+      for (uint8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M203 T", i);
         SERIAL_EMV(" E", VOLUMETRIC_UNIT(mechanics.max_feedrate_mm_s[E_AXIS + i]), 3);
       }
@@ -1218,7 +1218,7 @@ void EEPROM::Factory_Settings() {
     #endif
     SERIAL_EOL();
     #if EXTRUDERS > 1
-      for (int8_t i = 0; i < EXTRUDERS; i++) {
+      for (uint8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M201 T", i);
         SERIAL_EMV(" E", VOLUMETRIC_UNIT(mechanics.max_acceleration_mm_per_s2[E_AXIS + i]));
       }
@@ -1232,7 +1232,7 @@ void EEPROM::Factory_Settings() {
     #endif
     SERIAL_EOL();
     #if EXTRUDERS > 1
-      for (int8_t i = 0; i < EXTRUDERS; i++) {
+      for (uint8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M204 T", i);
         SERIAL_EMV(" R", LINEAR_UNIT(mechanics.retract_acceleration[i]), 3);
       }
@@ -1250,7 +1250,7 @@ void EEPROM::Factory_Settings() {
     #endif
     SERIAL_EOL();
     #if (EXTRUDERS > 1)
-      for(int8_t i = 0; i < EXTRUDERS; i++) {
+      for(uint8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M205 T", i);
         SERIAL_EMV(" E" , LINEAR_UNIT(mechanics.max_jerk[E_AXIS + i]), 3);
       }
@@ -1265,7 +1265,7 @@ void EEPROM::Factory_Settings() {
 
     #if HOTENDS > 1
       CONFIG_MSG_START("Hotend offset (mm):");
-      for (int8_t h = 1; h < HOTENDS; h++) {
+      for (uint8_t h = 1; h < HOTENDS; h++) {
         SERIAL_SMV(CFG, "  M218 H", h);
         SERIAL_MV(" X", LINEAR_UNIT(printer.hotend_offset[X_AXIS][h]), 3);
         SERIAL_MV(" Y", LINEAR_UNIT(printer.hotend_offset[Y_AXIS][h]), 3);
@@ -1308,7 +1308,7 @@ void EEPROM::Factory_Settings() {
 
     #if HEATER_USES_AD595
       CONFIG_MSG_START("AD595 Offset and Gain:");
-      for (int8_t h = 0; h < HOTENDS; h++) {
+      for (uint8_t h = 0; h < HOTENDS; h++) {
         SERIAL_SMV(CFG, "  M595 H", h);
         SERIAL_MV(" O", thermalManager.ad595_offset[h]);
         SERIAL_EMV(", S", thermalManager.ad595_gain[h]);
@@ -1360,7 +1360,7 @@ void EEPROM::Factory_Settings() {
 
     #if ENABLED(ULTIPANEL)
       CONFIG_MSG_START("Material heatup parameters:");
-      for (int8_t i = 0; i < COUNT(lcd_preheat_hotend_temp); i++) {
+      for (uint8_t i = 0; i < COUNT(lcd_preheat_hotend_temp); i++) {
         SERIAL_SMV(CFG, "  M145 S", i);
         SERIAL_MV(" H", TEMP_UNIT(lcd_preheat_hotend_temp[i]));
         SERIAL_MV(" B", TEMP_UNIT(lcd_preheat_bed_temp[i]));
@@ -1385,7 +1385,7 @@ void EEPROM::Factory_Settings() {
             SERIAL_LMV(CFG, "  M301 L", thermalManager.lpq_len);
           #endif
         #elif HOTENDS > 1
-          for (int8_t h = 0; h < HOTENDS; h++) {
+          for (uint8_t h = 0; h < HOTENDS; h++) {
             SERIAL_SMV(CFG, "  M301 H", h);
             SERIAL_MV(" P", PID_PARAM(Kp, h));
             SERIAL_MV(" I", PID_PARAM(Ki, h));

--- a/MK4duo/src/endstop/endstops.cpp
+++ b/MK4duo/src/endstop/endstops.cpp
@@ -226,7 +226,7 @@ void Endstops::report_state() {
       if (stepper.abort_on_endstop_hit) {
         card.sdprinting = false;
         card.closeFile();
-        quickstop_stepper();
+        printer.quickstop_stepper();
         thermalManager.disable_all_heaters(); // switch off all heaters.
         thermalManager.disable_all_coolers();
       }

--- a/MK4duo/src/gcode/calibrate/g29_mbl.h
+++ b/MK4duo/src/gcode/calibrate/g29_mbl.h
@@ -62,7 +62,7 @@
     #endif
 
     const MeshLevelingState state = parser.seen('S') ? (MeshLevelingState)parser.value_byte() : MeshReport;
-    if (!WITHIN(state, 0, 5)) {
+    if (state > 5) {
       SERIAL_MSG("S out of range (0-5).");
       return;
     }

--- a/MK4duo/src/gcode/control/m42.h
+++ b/MK4duo/src/gcode/control/m42.h
@@ -52,7 +52,7 @@ inline void gcode_M42(void) {
 
   #if FAN_COUNT > 0
     LOOP_FAN() {
-      if (fans.pin[f] = pin_number) {
+      if (fans.pin[f] == pin_number) {
         fans.Speed[f] = pin_status;
       }
     }

--- a/MK4duo/src/gcode/debug/m43.h
+++ b/MK4duo/src/gcode/debug/m43.h
@@ -256,7 +256,7 @@
       }
 
       #if HAS(RESUME_CONTINUE)
-        wait_for_user = true;
+        printer.wait_for_user = true;
         KEEPALIVE_STATE(PAUSED_FOR_USER);
       #endif
 
@@ -275,7 +275,7 @@
         }
 
         #if HAS(RESUME_CONTINUE)
-          if (!wait_for_user) {
+          if (!printer.wait_for_user) {
             KEEPALIVE_STATE(IN_HANDLER);
             break;
           }

--- a/MK4duo/src/gcode/mixing/m163_m165.h
+++ b/MK4duo/src/gcode/mixing/m163_m165.h
@@ -40,10 +40,10 @@
    */
   inline void gcode_M163(void) {
     int mix_index = parser.seen('S') ? parser.value_int() : 0;
-    if (mix_index < MIXING_STEPPERS) {
+    if (WITHIN(mix_index, 0, MIXING_STEPPERS)) {
       float mix_value = parser.seen('P') ? parser.value_float() : 0.0;
       NOLESS(mix_value, 0.0);
-      printer.mixing_factor[mix_index] = RECIPROCAL(mix_value);
+      printer.mixing_factor[mix_index] = mix_value;
     }
   }
 
@@ -59,12 +59,8 @@
      */
     inline void gcode_M164(void) {
       int tool_index = parser.seen('S') ? parser.value_int() : 0;
-      if (tool_index < MIXING_VIRTUAL_TOOLS) {
-        normalize_mix();
-        for (uint8_t i = 0; i < MIXING_STEPPERS; i++) {
-          printer.mixing_virtual_tool_mix[tool_index][i] = printer.mixing_factor[i];
-        }
-      }
+      if (WITHIN(tool_index, 0, MIXING_VIRTUAL_TOOLS))
+        printer.store_normalized_mixing_factors(tool_index);
     }
 
   #endif
@@ -74,7 +70,6 @@
   /**
    * M165: Set multiple mix factors for a mixing extruder.
    *       Factors that are left out will be set to 0.
-   *       All factors together must add up to 1.0.
    *
    *   A[factor] Mix factor for extruder stepper 1
    *   B[factor] Mix factor for extruder stepper 2
@@ -84,6 +79,6 @@
    *   I[factor] Mix factor for extruder stepper 6
    *
    */
-  inline void gcode_M165(void) { gcode_get_mix(); }
+  inline void gcode_M165(void) { printer.get_mix_from_command(); }
 
 #endif  // COLOR_MIXING_EXTRUDER

--- a/MK4duo/src/gcode/tools/tcode.h
+++ b/MK4duo/src/gcode/tools/tcode.h
@@ -91,4 +91,6 @@ inline void gcode_T(void) {
       SERIAL_EM("<<< gcode_T");
     }
   #endif
+
+  UNUSED(tool_id);
 }

--- a/MK4duo/src/lcd/ultralcd_impl_HD44780.h
+++ b/MK4duo/src/lcd/ultralcd_impl_HD44780.h
@@ -273,7 +273,7 @@ const static PROGMEM byte feedrate[8] = {
   B00000
 };
 
-const static PROGMEM byte clock[8] = {
+const static PROGMEM byte time_clock[8] = {
   B00000,
   B01110,
   B10011,
@@ -349,7 +349,7 @@ static void lcd_set_custom_characters(
   createChar_P(LCD_DEGREE_CHAR, degree);
   createChar_P(LCD_STR_THERMOMETER[0], thermometer);
   createChar_P(LCD_FEEDRATE_CHAR, feedrate);
-  createChar_P(LCD_CLOCK_CHAR, clock);
+  createChar_P(LCD_CLOCK_CHAR, time_clock);
 
   #if HAS_SDSUPPORT
     #if ENABLED(LCD_PROGRESS_BAR)

--- a/MK4duo/src/pins.h
+++ b/MK4duo/src/pins.h
@@ -337,9 +337,9 @@
                         PS_ON_PIN, HEATER_BED_PIN, FAN_PIN, \
                         _H0_PINS _H1_PINS _H2_PINS _H3_PINS \
                         _E0_PINS _E1_PINS _E2_PINS _E3_PINS _E4_PINS _E5_PINS \
-                        analogInputToDigitalPin(TEMP_BED_PIN), \
-                        analogInputToDigitalPin(TEMP_CHAMBER_PIN), \
-                        analogInputToDigitalPin(TEMP_COOLER_PIN), \
+                        (int8_t) analogInputToDigitalPin(TEMP_BED_PIN), \
+                        (int8_t) analogInputToDigitalPin(TEMP_CHAMBER_PIN), \
+                        (int8_t) analogInputToDigitalPin(TEMP_COOLER_PIN), \
                         COOLER_PIN, LASER_PWR_PIN, LASER_PWM_PIN, \
                         FLOWMETER_PIN \
                        }

--- a/MK4duo/src/printer/printer.cpp
+++ b/MK4duo/src/printer/printer.cpp
@@ -79,7 +79,7 @@ PrinterMode Printer::mode =
 PrintCounter Printer::print_job_counter = PrintCounter();
 
 #if ENABLED(COLOR_MIXING_EXTRUDER)
-  float Printer::mixing_factor[MIXING_STEPPERS]; // Reciprocal of mix proportion. 0.0 = off, otherwise >= 1.0
+  float Printer::mixing_factor[MIXING_STEPPERS]; // Mix proportion. 0.0 = off
   #if MIXING_VIRTUAL_TOOLS  > 1
     float Printer::mixing_virtual_tool_mix[MIXING_VIRTUAL_TOOLS][MIXING_STEPPERS];
   #endif
@@ -368,10 +368,11 @@ void Printer::setup() {
 
   #if ENABLED(COLOR_MIXING_EXTRUDER) && MIXING_VIRTUAL_TOOLS > 1
     // Initialize mixing to 100% color 1
-    for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
-      mixing_factor[i] = (i == 0) ? 1.0 : 0.0;
-    for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS; t++)
-      for (uint8_t i = 0; i < MIXING_STEPPERS; i++)
+    mixing_factor[0] = 1.0;
+    for (uint8_t i = 1; i < MIXING_STEPPERS; ++i) mixing_factor[i] = 0.0;
+
+    for (uint8_t t = 0; t < MIXING_VIRTUAL_TOOLS; ++t)
+      for (uint8_t i = 0; i < MIXING_STEPPERS; ++i)
         mixing_virtual_tool_mix[t][i] = mixing_factor[i];
   #endif
 
@@ -462,7 +463,7 @@ void Printer::get_destination_from_command() {
     print_job_counter.data.filamentUsed += (mechanics.destination[E_AXIS] - mechanics.current_position[E_AXIS]);
 
   #if ENABLED(COLOR_MIXING_EXTRUDER)
-    gcode_get_mix();
+    get_mix_from_command();
   #endif
 
   #if ENABLED(RFID_MODULE)
@@ -1642,6 +1643,46 @@ void Printer::handle_Interrupt_Event() {
   }
 
 #endif // HAS_SDSUPPORT
+
+#if ENABLED(COLOR_MIXING_EXTRUDER)
+
+   /** Normalize mixing factors with a very simple math
+    *
+    *  F1 + ... + Fn == factors_sum
+    *
+    * (F1/factors_sum) + ... + (Fn/factors_sum) == (factors_sum/factors_sum) == 1.0
+    *
+    * This means that (F1/factors_sum), ... , (Fn/factors_sum) are normalized values!
+    *
+    * If factors_sum == 0, it means that F1 == ... == Fn == 0.0 (already normalized values)
+    */
+    void Printer::store_normalized_mixing_factors(uint8_t tool_index) {
+      float factors_sum = 0.0;
+
+      // We calculate the sum of all factors
+      for(uint8_t index= 0; index < MIXING_STEPPERS; ++index) {
+        factors_sum += mixing_factor[index];
+      }
+
+      if(factors_sum <= 0.0001) return;
+
+      // We normalize values
+      for(uint8_t index= 0; index < MIXING_STEPPERS; ++index){
+        mixing_virtual_tool_mix[tool_index][index] = mixing_factor[index] / factors_sum;
+      }
+    }
+
+    void Printer::get_mix_from_command() {
+      if(MIXING_STEPPERS >= 1) mixing_factor[0] = parser.seen('A') ? parser.value_float() : 0.0;
+      if(MIXING_STEPPERS >= 2) mixing_factor[1] = parser.seen('B') ? parser.value_float() : 0.0;
+      if(MIXING_STEPPERS >= 3) mixing_factor[2] = parser.seen('C') ? parser.value_float() : 0.0;
+      if(MIXING_STEPPERS >= 4) mixing_factor[3] = parser.seen('D') ? parser.value_float() : 0.0;
+      if(MIXING_STEPPERS >= 5) mixing_factor[4] = parser.seen('H') ? parser.value_float() : 0.0;
+      if(MIXING_STEPPERS == 6) mixing_factor[5] = parser.seen('I') ? parser.value_float() : 0.0;
+
+      for(uint8_t i = 0; i < MIXING_STEPPERS; ++i) NOLESS(mixing_factor[i], 0.0);
+    }
+#endif
 
 #if ENABLED(FWRETRACT)
 

--- a/MK4duo/src/printer/printer.h
+++ b/MK4duo/src/printer/printer.h
@@ -182,6 +182,11 @@ class Printer {
       static void stopSDPrint(const bool store_location);
     #endif
 
+    #if ENABLED(COLOR_MIXING_EXTRUDER)
+      static void store_normalized_mixing_factors(uint8_t tool_index);
+      static void get_mix_from_command();
+    #endif
+
     #if ENABLED(FWRETRACT)
       static void retract(const bool retracting, const bool swapping=false);
     #endif

--- a/MK4duo/src/utility/pinsdebug.h
+++ b/MK4duo/src/utility/pinsdebug.h
@@ -809,6 +809,7 @@ static bool pwm_status(uint8_t pin) {
     default:
       return false;
   }
+  UNUSED(buffer);
   SERIAL_MSG("  ");
 } // pwm_status
 
@@ -976,9 +977,10 @@ static bool pwm_status(uint8_t pin) {
           break;
       #endif
 
-      case NOT_ON_TIMER: break;
-
+      case NOT_ON_TIMER:
+      default: break;
     }
+    UNUSED(WGM);
     SERIAL_MSG("  ");
   }  // pwm_details
 


### PR DESCRIPTION
Fix warnings and errors both from #199 and from #204.

Added full COLOR_MIXING_EXTRUDER support, implementing get_mix_from_command() and store_normalized_mixing_factors().
Old behavior of mixing factors is preserved (you can still insert values which add up to 1.0) but it's now possible to insert values as you want (like 10, 37, 85, 0 , 2). They will be normalized before being stored.