### PR TITLE
added BOARD_RAMPS4DUE_NEXTION

### DIFF
--- a/MK4duo/Boards.h
+++ b/MK4duo/Boards.h
@@ -180,6 +180,7 @@
 #define BOARD_RAMPS_SMART_HHF 1414    // RAMPS-SMART (Power outputs: Hotend0, Hotend1, Fan)
 
 #define BOARD_RAMPS4DUE       1433    // RAMPS4DUE with AndrewBCN's RAMPS mods (http://forums.reprap.org/read.php?219,479626,page=1) ARM 32 bit board
+#define BOARD_RAMPS4DUE_NEXTION  1434 // RAMPS4DUE with ARM 32 bit board + NEXTION on SERIAL 1
 
 #define BOARD_ALLIGATOR       1502    // ALLIGATOR R2 ARM 32 bit board
 #define BOARD_ALLIGATOR_V3    1503    // ALLIGATOR R3 ARM 32 bit board

--- a/MK4duo/src/HAL/HAL_DUE/spi_pins_Due.h
+++ b/MK4duo/src/HAL/HAL_DUE/spi_pins_Due.h
@@ -28,8 +28,13 @@
  *
  * Available chip select pins for HW SPI are 4 10 52 77
  */
-#if (SDSS == 4) || (SDSS == 10) || (SDSS == 52)|| (SDSS == 59) || (SDSS == 60) || (SDSS == 77)
-  #if (SDSS == 4)
+#define RAMPS4DUE  ((MOTHERBOARD == BOARD_RAMPS4DUE) ||  (MOTHERBOARD == BOARD_RAMPS4DUE_NEXTION))
+#if (SDSS == 4) || (SDSS == 10) || (SDSS == 52)|| (SDSS == 59) || (SDSS == 60) || (SDSS == 77) || (RAMPS4DUE && (SDSS == 53))
+	#if (RAMPS4DUE && (SDSS == 53))
+	  // use same CS (spi_pin=D53) and CD (D49) as in mega2560+ramps1.4 configuration
+		#define SPI_PIN           53
+		#define SPI_CHAN          0
+  #elif (SDSS == 4)
     #define SPI_PIN         87
     #define SPI_CHAN        1
   #elif (SDSS == 10)

--- a/MK4duo/src/boards/1434.h
+++ b/MK4duo/src/boards/1434.h
@@ -1,0 +1,196 @@
+/****************************************************************************************
+* 1434
+* Arduino Due pin assignment
+* for RAMPS4DUE (http://forums.reprap.org/read.php?219,479626,page=1)
+****************************************************************************************/
+
+//###CHIP
+#if DISABLED(ARDUINO_ARCH_SAM)
+  #error Oops!  Make sure you have 'Arduino Due' selected from the 'Tools -> Boards' menu.
+#endif
+//@@@
+
+// uncomment if you have connected NEXTION display RX to due TX1 (D18) and TX to RX1 (D19) on second serial (numbered as 1 i.e. in zero-based system) pins and changed Zmin and Zmax to D3 and D14, respectively
+#define NEXTION_ON_SERIAL1
+
+#if ENABLED(NEXTION_ON_SERIAL1) && (NEXTION_SERIAL != 1)
+  #error Make sure you have Nextion display connected to right serial port.
+#endif
+
+#define KNOWN_BOARD 1
+
+//###BOARD_NAME
+#if DISABLED(BOARD_NAME)
+	#define BOARD_NAME "RAMPS4DUE_NEXTION"
+#endif
+//@@@
+
+
+//###X_AXIS
+#define ORIG_X_STEP_PIN 54
+#define ORIG_X_DIR_PIN 55
+#define ORIG_X_ENABLE_PIN 38
+#define ORIG_X_CS_PIN -1
+
+//###Y_AXIS
+#define ORIG_Y_STEP_PIN 60
+#define ORIG_Y_DIR_PIN 61
+#define ORIG_Y_ENABLE_PIN 56
+#define ORIG_Y_CS_PIN -1
+
+//###Z_AXIS
+#define ORIG_Z_STEP_PIN 46
+#define ORIG_Z_DIR_PIN 48
+#define ORIG_Z_ENABLE_PIN 62
+#define ORIG_Z_CS_PIN -1
+
+//###EXTRUDER_0
+#define ORIG_E0_STEP_PIN 26
+#define ORIG_E0_DIR_PIN 28
+#define ORIG_E0_ENABLE_PIN 24
+#define ORIG_E0_CS_PIN -1
+#define ORIG_SOL0_PIN -1
+
+//###EXTRUDER_1
+#define ORIG_E1_STEP_PIN 36
+#define ORIG_E1_DIR_PIN 34
+#define ORIG_E1_ENABLE_PIN 30
+#define ORIG_E1_CS_PIN -1
+#define ORIG_SOL1_PIN -1
+
+//###EXTRUDER_2
+#define ORIG_E2_STEP_PIN -1
+#define ORIG_E2_DIR_PIN -1
+#define ORIG_E2_ENABLE_PIN -1
+#define ORIG_E2_CS_PIN -1
+#define ORIG_SOL2_PIN -1
+
+//###EXTRUDER_3
+#define ORIG_E3_STEP_PIN -1
+#define ORIG_E3_DIR_PIN -1
+#define ORIG_E3_ENABLE_PIN -1
+#define ORIG_E3_CS_PIN -1
+#define ORIG_SOL3_PIN -1
+
+//###EXTRUDER_4
+#define ORIG_E4_STEP_PIN -1
+#define ORIG_E4_DIR_PIN -1
+#define ORIG_E4_ENABLE_PIN -1
+#define ORIG_E4_CS_PIN -1
+#define ORIG_SOL4_PIN -1
+
+//###EXTRUDER_5
+#define ORIG_E5_STEP_PIN -1
+#define ORIG_E5_DIR_PIN -1
+#define ORIG_E5_ENABLE_PIN -1
+#define ORIG_E5_CS_PIN -1
+#define ORIG_SOL5_PIN -1
+
+//###EXTRUDER_6
+#define ORIG_E6_STEP_PIN -1
+#define ORIG_E6_DIR_PIN -1
+#define ORIG_E6_ENABLE_PIN -1
+#define ORIG_E6_CS_PIN -1
+#define ORIG_SOL6_PIN -1
+
+//###EXTRUDER_7
+#define ORIG_E7_STEP_PIN -1
+#define ORIG_E7_DIR_PIN -1
+#define ORIG_E7_ENABLE_PIN -1
+#define ORIG_E7_CS_PIN -1
+#define ORIG_SOL7_PIN -1
+
+//###ENDSTOP
+// X endstop
+#if DISABLED(NEXTION_ON_SERIAL1)
+  #define ORIG_X_MIN_PIN         3
+#else
+  #define ORIG_X_MIN_PIN        -1
+#endif
+#define ORIG_X_MAX_PIN 2
+// Y endstop
+#if DISABLED(NEXTION_ON_SERIAL1)
+  #define ORIG_Y_MIN_PIN        14
+#else
+  #define ORIG_Y_MIN_PIN        -1
+#endif
+#define ORIG_Y_MAX_PIN 15
+
+// Z endstop
+#if DISABLED(NEXTION_ON_SERIAL1)
+  #define ORIG_Z_MIN_PIN        18
+  #define ORIG_Z_MAX_PIN        19
+#else
+  #define ORIG_Z_MIN_PIN         3
+  #define ORIG_Z_MAX_PIN        14
+#endif
+
+#define ORIG_Z2_MIN_PIN -1
+#define ORIG_Z2_MAX_PIN -1
+#define ORIG_Z3_MIN_PIN -1
+#define ORIG_Z3_MAX_PIN -1
+#define ORIG_Z4_MIN_PIN -1
+#define ORIG_Z4_MAX_PIN -1
+#define ORIG_E_MIN_PIN -1
+#define ORIG_Z_PROBE_PIN -1
+
+//###SINGLE_ENDSTOP
+#define X_STOP_PIN -1
+#define Y_STOP_PIN -1
+#define Z_STOP_PIN -1
+
+//###HEATER
+#define ORIG_HEATER_0_PIN 10
+#define ORIG_HEATER_1_PIN -1
+#define ORIG_HEATER_2_PIN -1
+#define ORIG_HEATER_3_PIN -1
+#define ORIG_HEATER_BED_PIN 8
+#define ORIG_HEATER_CHAMBER_PIN -1
+#define ORIG_COOLER_PIN -1
+
+//###TEMPERATURE
+#define ORIG_TEMP_0_PIN 9
+#define ORIG_TEMP_1_PIN -1
+#define ORIG_TEMP_2_PIN -1
+#define ORIG_TEMP_3_PIN -1
+#define ORIG_TEMP_BED_PIN 10
+#define ORIG_TEMP_CHAMBER_PIN -1
+#define ORIG_TEMP_COOLER_PIN -1
+
+//###FAN
+#define ORIG_FAN_PIN 9
+#define ORIG_FAN1_PIN -1
+#define ORIG_FAN2_PIN -1
+#define ORIG_FAN3_PIN -1
+
+//###MISC
+#define ORIG_PS_ON_PIN 12
+#define ORIG_BEEPER_PIN -1
+#define LED_PIN 13
+#define SDPOWER -1
+#define SD_DETECT_PIN -1
+#define SDSS 53
+#define KILL_PIN -1
+#define DEBUG_PIN -1
+#define SUICIDE_PIN -1
+
+//###LASER
+#define ORIG_LASER_PWR_PIN -1
+#define ORIG_LASER_PWM_PIN -1
+
+//###SERVOS
+#if NUM_SERVOS > 0
+	#define SERVO0_PIN -1
+	#if NUM_SERVOS > 1
+		#define SERVO1_PIN -1
+		#if NUM_SERVOS > 2
+			#define SERVO2_PIN -1
+			#if NUM_SERVOS > 3
+				#define SERVO3_PIN -1
+			#endif
+		#endif
+	#endif
+#endif
+//@@@
+
+


### PR DESCRIPTION
BOARD_RAMPS4DUE_NEXTION #1434 (clone of #1433), which supports following HW configuration: Due + RAMPS4DUE + SD card (on SPI channel 0) + NEXTION display (on serial 1)

Comments:
1.
I made this board as a separate item/number, so that one knows that it has to rewire electronics (endstop switches) to work properly, since Nextion display connects to serial1 pins on Due (use define NEXTION_ON_SERIAL1) , which are same pins for endstops pins on RAMPS4DUE.

So you have to connect Nextion display RX to Due TX1 (D18) and Nextion TX to Due RX1 (D19) on second serial (numbered as 1 i.e. in zero-based system) pins and changed Zmin and Zmax to D3 and D14, respectively.

2.
For simplicity SD is connected directly to the due on the bottom side of main cpu board to SPI channel 0 and not via ramps board.


