### PR TITLE
PIDTEMP small fixes

### DIFF
--- a/MK4duo/src/conditionals_pre.h
+++ b/MK4duo/src/conditionals_pre.h
@@ -432,6 +432,7 @@
     #define TARGET_EXTRUDER 0
   #elif EXTRUDERS == 0
     #undef PIDTEMP
+    #define PIDTEMP false
     #undef FWRETRACT
     #define XYZE_N    XYZ
     #define E_AXIS_N  0

--- a/MK4duo/src/gcode/config/m301.h
+++ b/MK4duo/src/gcode/config/m301.h
@@ -73,4 +73,4 @@
     }
   }
 
-#endif // ENABLED(PIDTEMP)
+#endif // HAS_PID

--- a/MK4duo/src/gcode/config/m305.h
+++ b/MK4duo/src/gcode/config/m305.h
@@ -42,4 +42,4 @@
     SERIAL_EMV(" d:", heaters[CHAMBER_INDEX].Kd);
   }
 
-#endif // NABLED(PIDTEMPCHAMBER)
+#endif // PIDTEMPCHAMBER

--- a/MK4duo/src/lcd/ultralcd.cpp
+++ b/MK4duo/src/lcd/ultralcd.cpp
@@ -418,7 +418,7 @@ uint16_t max_display_update_time = 0;
     uint8_t lcd_sd_status;
   #endif
 
-  #if PIDTEMP
+  #if (PIDTEMP)
     float raw_Ki, raw_Kd; // place-holders for Ki and Kd edits
   #endif
 

--- a/MK4duo/src/temperature/temperature.cpp
+++ b/MK4duo/src/temperature/temperature.cpp
@@ -125,7 +125,7 @@ void Temperature::init() {
     MCUCR = _BV(JTD);
   #endif
 
-  #if ENABLED(PIDTEMP) && ENABLED(PID_ADD_EXTRUSION_RATE)
+  #if (PIDTEMP) && ENABLED(PID_ADD_EXTRUSION_RATE)
     last_e_position = 0;
   #endif
 
@@ -574,7 +574,7 @@ void Temperature::PID_autotune(int8_t temp_controller, const float temp, int ncy
 
         SERIAL_EM(MSG_PID_AUTOTUNE_FINISHED);
 
-        #if ENABLED(PIDTEMP)
+        #if (PIDTEMP)
           if (temp_controller >= 0) {
             SERIAL_MV(MSG_KP, workKp);
             SERIAL_MV(MSG_KI, workKi);


### PR DESCRIPTION
Really small fixes to PIDTEMP macro. In conditionals_pre.h, if the machine has no extruders (maybe because it is used as laser cutting or cncrouter), PIDTEMP must be defined as false, actually PIDTEMP must be always defined! @MagoKimbra , should we put some new sanitycheck controls to check if PIDTEMP, PIDTEMPBED, ... , PWM_HARDWARE, ... and macros like those are defined?