### PR TITLE
Try to fix #199 again

### DIFF
--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -50,7 +50,7 @@
  *  M203  XYZ E0 ...      mechanics.max_feedrate_mm_s X,Y,Z,E0 ... (float x9)
  *  M201  XYZ E0 ...      mechanics.max_acceleration_mm_per_s2 X,Y,Z,E0 ... (uint32_t x9)
  *  M204  P               mechanics.acceleration                (float)
- *  M204  R   E0 ...      mechanics.retract_acceleration        (float x6)
+ *  M204  R   E0 ...      Tools::retract_acceleration           (float x6)
  *  M204  T               mechanics.travel_acceleration         (float)
  *  M205  S               mechanics.min_feedrate_mm_s           (float)
  *  M205  T               mechanics.min_travel_feedrate_mm_s    (float)
@@ -315,7 +315,9 @@ void EEPROM::Postprocess() {
     EEPROM_WRITE(mechanics.max_feedrate_mm_s);
     EEPROM_WRITE(mechanics.max_acceleration_mm_per_s2);
     EEPROM_WRITE(mechanics.acceleration);
-    EEPROM_WRITE(mechanics.retract_acceleration);
+    #if EXTRUDERS > 0
+      EEPROM_WRITE(Tools::retract_acceleration);
+    #endif
     EEPROM_WRITE(mechanics.travel_acceleration);
     EEPROM_WRITE(mechanics.min_feedrate_mm_s);
     EEPROM_WRITE(mechanics.min_travel_feedrate_mm_s);
@@ -628,7 +630,9 @@ void EEPROM::Postprocess() {
       EEPROM_READ(mechanics.max_feedrate_mm_s);
       EEPROM_READ(mechanics.max_acceleration_mm_per_s2);
       EEPROM_READ(mechanics.acceleration);
-      EEPROM_READ(mechanics.retract_acceleration);
+      #if EXTRUDERS > 0
+        EEPROM_READ(Tools::retract_acceleration);
+      #endif
       EEPROM_READ(mechanics.travel_acceleration);
       EEPROM_READ(mechanics.min_feedrate_mm_s);
       EEPROM_READ(mechanics.min_travel_feedrate_mm_s);
@@ -929,10 +933,12 @@ void EEPROM::Factory_Settings() {
     mechanics.max_acceleration_mm_per_s2[i] = tmp3[i < COUNT(tmp3) ? i : COUNT(tmp3) - 1];
   }
 
-  for (uint8_t i = 0; i < EXTRUDERS; i++) {
-    mechanics.retract_acceleration[i]       = tmp4[i < COUNT(tmp4) ? i : COUNT(tmp4) - 1];
-    mechanics.max_jerk[E_AXIS + i]          = tmp5[i < COUNT(tmp5) ? i : COUNT(tmp5) - 1];
-  }
+  #if EXTRUDERS > 0
+    for (uint8_t i = 0; i < EXTRUDERS; i++) {
+      Tools::retract_acceleration[i]          = tmp4[i < COUNT(tmp4) ? i : COUNT(tmp4) - 1];
+      mechanics.max_jerk[E_AXIS + i]          = tmp5[i < COUNT(tmp5) ? i : COUNT(tmp5) - 1];
+    }
+  #endif
 
   static_assert(
     tmp10[X_AXIS][0] == 0 && tmp10[Y_AXIS][0] == 0 && tmp10[Z_AXIS][0] == 0,
@@ -1194,13 +1200,13 @@ void EEPROM::Factory_Settings() {
     SERIAL_SMV(CFG,"  M204 P", LINEAR_UNIT(mechanics.acceleration), 3);
     SERIAL_MV(" V", LINEAR_UNIT(mechanics.travel_acceleration), 3);
     #if EXTRUDERS == 1
-      SERIAL_MV(" T0 R", LINEAR_UNIT(mechanics.retract_acceleration[0]), 3);
+      SERIAL_MV(" T0 R", LINEAR_UNIT(Tools::retract_acceleration[0]), 3);
     #endif
     SERIAL_EOL();
     #if EXTRUDERS > 1
       for (int8_t i = 0; i < EXTRUDERS; i++) {
         SERIAL_SMV(CFG, "  M204 T", i);
-        SERIAL_EMV(" R", LINEAR_UNIT(mechanics.retract_acceleration[i]), 3);
+        SERIAL_EMV(" R", LINEAR_UNIT(Tools::retract_acceleration[i]), 3);
       }
     #endif
 

--- a/MK4duo/src/gcode/config/m204.h
+++ b/MK4duo/src/gcode/config/m204.h
@@ -49,10 +49,12 @@ inline void gcode_M204(void) {
     mechanics.acceleration = parser.value_linear_units();
     SERIAL_EMV("Setting Print acceleration: ", mechanics.acceleration );
   }
-  if (parser.seen('R')) {
-    mechanics.retract_acceleration[TARGET_EXTRUDER] = parser.value_linear_units();
-    SERIAL_EMV("Setting Retract acceleration: ", mechanics.retract_acceleration[TARGET_EXTRUDER]);
-  }
+  #if EXTRUDERS > 0
+    if (parser.seen('R')) {
+      Tools::retract_acceleration[TARGET_EXTRUDER] = parser.value_linear_units();
+      SERIAL_EMV("Setting Retract acceleration: ", Tools::retract_acceleration[TARGET_EXTRUDER]);
+    }
+  #endif
   if (parser.seen('V')) {
     mechanics.travel_acceleration = parser.value_linear_units();
     SERIAL_EMV("Setting Travel acceleration: ", mechanics.travel_acceleration );

--- a/MK4duo/src/language/language_zh_CN.h
+++ b/MK4duo/src/language/language_zh_CN.h
@@ -101,7 +101,7 @@
 #define MSG_VMIN                            _UxGT("最小进料速率")  //"Vmin"  min_feedrate_mm_s
 #define MSG_VTRAV_MIN                       _UxGT("最小移动速率")  //"VTrav min" min_travel_feedrate_mm_s, (target) speed of the move
 #define MSG_AMAX                            _UxGT("最大打印加速度")  //"Amax " max_acceleration_mm_per_s2, acceleration in units/s^2 for print moves
-#define MSG_A_RETRACT                       _UxGT("收进加速度")  //"A-retract" retract_acceleration, E acceleration in mm/s^2 for retracts
+#define MSG_A_RETRACT                       _UxGT("收进加速度")  //"A-retract" Tools::retract_acceleration, E acceleration in mm/s^2 for retracts
 #define MSG_A_TRAVEL                        _UxGT("非打印移动加速度")  //"A-travel" travel_acceleration, X, Y, Z acceleration in mm/s^2 for travel (non printing) moves
 #define MSG_STEPS_PER_MM                    _UxGT("轴步数/mm")  //"Steps/mm" axis_steps_per_mm, axis steps-per-unit G92
 #define MSG_XSTEPS                          _UxGT("X轴步数/mm")  //"Xsteps/mm" axis_steps_per_mm, axis steps-per-unit G92

--- a/MK4duo/src/language/language_zh_TW.h
+++ b/MK4duo/src/language/language_zh_TW.h
@@ -101,7 +101,7 @@
 #define MSG_VMIN                            _UxGT("最小進料速率")  //"Vmin"  min_feedrate_mm_s
 #define MSG_VTRAV_MIN                       _UxGT("最小移動速率")  //"VTrav min" min_travel_feedrate_mm_s, (target) speed of the move
 #define MSG_AMAX                            _UxGT("最大列印加速度")  //"Amax " max_acceleration_mm_per_s2, acceleration in units/s^2 for print moves
-#define MSG_A_RETRACT                       _UxGT("收進加速度")  //"A-retract" retract_acceleration, E acceleration in mm/s^2 for retracts
+#define MSG_A_RETRACT                       _UxGT("收進加速度")  //"A-retract" Tools::retract_acceleration, E acceleration in mm/s^2 for retracts
 #define MSG_A_TRAVEL                        _UxGT("非列印移動加速度")  //"A-travel" travel_acceleration, X, Y, Z acceleration in mm/s^2 for travel (non printing) moves
 #define MSG_STEPS_PER_MM                    _UxGT("軸步數/mm")  //"Steps/mm" axis_steps_per_mm, axis steps-per-unit G92
 #define MSG_XSTEPS                          _UxGT("X軸步數/mm")  //"Xsteps/mm" axis_steps_per_mm, axis steps-per-unit G92

--- a/MK4duo/src/lcd/ultralcd.cpp
+++ b/MK4duo/src/lcd/ultralcd.cpp
@@ -2662,23 +2662,23 @@ void kill_screen(const char* lcd_msg) {
 
     // M204 R Retract Acceleration
     #if EXTRUDERS > 1
-      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E, &mechanics.retract_acceleration[tools.active_extruder], 100, 99000);
-      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E1, &mechanics.retract_acceleration[0], 100, 99000);
-      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E2, &mechanics.retract_acceleration[1], 100, 99000);
+      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E, &Tools::retract_acceleration[Tools::active_extruder], 100, 99000);
+      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E1, &Tools::retract_acceleration[0], 100, 99000);
+      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E2, &Tools::retract_acceleration[1], 100, 99000);
       #if EXTRUDERS > 2
-        MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E3, &mechanics.retract_acceleration[2], 100, 99000);
+        MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E3, &Tools::retract_acceleration[2], 100, 99000);
         #if EXTRUDERS > 3
-          MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E4, &mechanics.retract_acceleration[3], 100, 99000);
+          MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E4, &Tools::retract_acceleration[3], 100, 99000);
           #if EXTRUDERS > 4
-            MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E5, &mechanics.retract_acceleration[4], 100, 99000);
-            #if EXTRUDERS > 4
-              MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E6, &mechanics.retract_acceleration[5], 100, 99000);
+            MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E5, &Tools::retract_acceleration[4], 100, 99000);
+            #if EXTRUDERS > 5
+              MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E6, &Tools::retract_acceleration[5], 100, 99000);
             #endif // EXTRUDERS > 5
           #endif // EXTRUDERS > 4
         #endif // EXTRUDERS > 3
       #endif // EXTRUDERS > 2
-    #else
-      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E, &mechanics.retract_acceleration[0], 100, 99000);
+    #elif EXTRUDERS == 1
+      MENU_ITEM_EDIT(float5, MSG_A_RETRACT MSG_E, &Tools::retract_acceleration[0], 100, 99000);
     #endif
 
     // M204 T Travel Acceleration
@@ -2699,7 +2699,7 @@ void kill_screen(const char* lcd_msg) {
           MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E4, &mechanics.max_acceleration_mm_per_s2[E_AXIS + 3], 100, 99000, _reset_e3_acceleration_rate);
           #if EXTRUDERS > 4
             MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E5, &mechanics.max_acceleration_mm_per_s2[E_AXIS + 4], 100, 99000, _reset_e4_acceleration_rate);
-            #if EXTRUDERS > 4
+            #if EXTRUDERS > 5
               MENU_ITEM_EDIT_CALLBACK(long5, MSG_AMAX MSG_E6, &mechanics.max_acceleration_mm_per_s2[E_AXIS + 5], 100, 99000, _reset_e5_acceleration_rate);
             #endif // EXTRUDERS > 5
           #endif // EXTRUDERS > 4
@@ -2735,7 +2735,7 @@ void kill_screen(const char* lcd_msg) {
           MENU_ITEM_EDIT(float3, MSG_VE_JERK MSG_E4, &mechanics.max_jerk[E_AXIS + 3], 1, 990);
           #if EXTRUDERS > 4
             MENU_ITEM_EDIT(float3, MSG_VE_JERK MSG_E5, &mechanics.max_jerk[E_AXIS + 4], 1, 990);
-            #if EXTRUDERS > 4
+            #if EXTRUDERS > 5
               MENU_ITEM_EDIT(float3, MSG_VE_JERK MSG_E6, &mechanics.max_jerk[E_AXIS + 5], 1, 990);
             #endif // EXTRUDERS > 5
           #endif // EXTRUDERS > 4

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -109,7 +109,6 @@ class Mechanics {
      * Acceleration and Jerk
      */
     float     acceleration                          = 0.0,
-              retract_acceleration[EXTRUDERS]       = { 0.0 },
               travel_acceleration                   = 0.0,
               max_jerk[XYZE_N]                      = { 0.0 };
     uint32_t  max_acceleration_steps_per_s2[XYZE_N] = { 0 },

--- a/MK4duo/src/planner/planner.cpp
+++ b/MK4duo/src/planner/planner.cpp
@@ -1038,8 +1038,10 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   const float steps_per_mm = block->step_event_count * inverse_millimeters;
   uint32_t accel;
   if (!block->steps[X_AXIS] && !block->steps[Y_AXIS] && !block->steps[Z_AXIS]) {
-    // convert to: mechanics.acceleration steps/sec^2
-    accel = CEIL(mechanics.retract_acceleration[extruder] * steps_per_mm);
+    #if EXTRUDERS > 0
+      // convert to: mechanics.acceleration steps/sec^2
+      accel = CEIL(Tools::retract_acceleration[extruder] * steps_per_mm);
+    #endif
   }
   else {
     #define LIMIT_ACCEL_LONG(AXIS,INDX) do{ \

--- a/MK4duo/src/tools/tools.cpp
+++ b/MK4duo/src/tools/tools.cpp
@@ -61,6 +61,8 @@
           Tools::retract_recover_feedrate_mm_s  = RETRACT_RECOVER_FEEDRATE;
   #endif
 
+  float   Tools::retract_acceleration[EXTRUDERS]  = ARRAY_BY_EXTRUDERS(0.0);
+
   #if HAS_EXT_ENCODER
     uint8_t Tools::encLastSignal[EXTRUDERS]           = ARRAY_BY_EXTRUDERS(0);
     int8_t  Tools::encLastDir[EXTRUDERS]              = ARRAY_BY_EXTRUDERS(1);

--- a/MK4duo/src/tools/tools.h
+++ b/MK4duo/src/tools/tools.h
@@ -55,9 +55,17 @@
         static bool   autoretract_enabled,
                       retracted[EXTRUDERS],
                       retracted_swap[EXTRUDERS];
-        static float  retract_length, retract_length_swap, retract_feedrate_mm_s, retract_zlift,
-                      retract_recover_length, retract_recover_length_swap, retract_recover_feedrate_mm_s;
+
+        static float  retract_length,
+                      retract_length_swap,
+                      retract_feedrate_mm_s,
+                      retract_zlift,
+                      retract_recover_length,
+                      retract_recover_length_swap,
+                      retract_recover_feedrate_mm_s;
       #endif
+
+      static float retract_acceleration[EXTRUDERS];
 
       #if HAS_EXT_ENCODER
         static uint8_t  encLastSignal[EXTRUDERS];           // what was the last signal


### PR DESCRIPTION
The retract_acceleration array was moved to the Tools class. Now everytime it's used in the code, is firstly checked that EXTRUDERS is > 0. Also, little fixes in ultralcd.cpp...