### PR TITLE
Fix #222 and some warnings

### DIFF
--- a/MK4duo/src/boards/1401.h
+++ b/MK4duo/src/boards/1401.h
@@ -168,6 +168,9 @@
 #endif
 //@@@
 
+//###UNKNOWN_PINS
+#define I2C_EEPROM
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)

--- a/MK4duo/src/gcode/calibrate/g29_abl.h
+++ b/MK4duo/src/gcode/calibrate/g29_abl.h
@@ -165,12 +165,12 @@ void out_of_range_error(const char* p_edge) {
       #define ABL_VAR
     #endif
 
-    ABL_VAR int verbose_level;
-    ABL_VAR float xProbe, yProbe, measured_z;
-    ABL_VAR bool dryrun, abl_should_enable;
+    ABL_VAR int verbose_level = 0;
+    ABL_VAR float xProbe = 0.0, yProbe = 0.0, measured_z = 0.0;
+    ABL_VAR bool dryrun = false, abl_should_enable = false;
 
     #if ENABLED(PROBE_MANUALLY) || ENABLED(AUTO_BED_LEVELING_LINEAR)
-      ABL_VAR int abl_probe_index;
+      ABL_VAR int abl_probe_index = 0;
     #endif
 
     #if HAS_SOFTWARE_ENDSTOPS && ENABLED(PROBE_MANUALLY)
@@ -180,14 +180,14 @@ void out_of_range_error(const char* p_edge) {
     #if ABL_GRID
 
       #if ENABLED(PROBE_MANUALLY)
-        ABL_VAR uint8_t PR_OUTER_VAR;
-        ABL_VAR  int8_t PR_INNER_VAR;
+        ABL_VAR uint8_t PR_OUTER_VAR = 0;
+        ABL_VAR  int8_t PR_INNER_VAR = 0;
       #endif
 
-      ABL_VAR int left_probe_bed_position,
-                  right_probe_bed_position,
-                  front_probe_bed_position,
-                  back_probe_bed_position;
+      ABL_VAR int left_probe_bed_position  = 0.0,
+                  right_probe_bed_position = 0.0,
+                  front_probe_bed_position = 0.0,
+                  back_probe_bed_position  = 0.0;
 
       ABL_VAR float xGridSpacing = 0.0,
                     yGridSpacing = 0.0;
@@ -195,7 +195,7 @@ void out_of_range_error(const char* p_edge) {
       #if ENABLED(AUTO_BED_LEVELING_LINEAR)
         ABL_VAR uint8_t abl_grid_points_x = GRID_MAX_POINTS_X,
                         abl_grid_points_y = GRID_MAX_POINTS_Y;
-        ABL_VAR bool    do_topography_map;
+        ABL_VAR bool    do_topography_map = false;
       #else // Bilinear
         uint8_t constexpr abl_grid_points_x = GRID_MAX_POINTS_X,
                           abl_grid_points_y = GRID_MAX_POINTS_Y;
@@ -203,7 +203,7 @@ void out_of_range_error(const char* p_edge) {
 
       #if ENABLED(AUTO_BED_LEVELING_LINEAR) || ENABLED(PROBE_MANUALLY)
         #if ENABLED(AUTO_BED_LEVELING_LINEAR)
-          ABL_VAR int abl2;
+          ABL_VAR int abl2 = 0;
         #else // Bilinear
           int constexpr abl2 = GRID_MAX_POINTS;
         #endif
@@ -211,7 +211,7 @@ void out_of_range_error(const char* p_edge) {
 
       #if ENABLED(AUTO_BED_LEVELING_BILINEAR)
 
-        ABL_VAR float zoffset;
+        ABL_VAR float zoffset = 0.0;
 
       #elif ENABLED(AUTO_BED_LEVELING_LINEAR)
 

--- a/MK4duo/src/gcode/temperature/m191.h
+++ b/MK4duo/src/gcode/temperature/m191.h
@@ -41,7 +41,7 @@
     bool no_wait_for_cooling = parser.seen('S');
     if (no_wait_for_cooling || parser.seen('R')) heaters[CHAMBER_INDEX].setTarget(parser.value_celsius());
 
-    printer.wait_chamber(no_wait_for_cooling);
+    thermalManager.wait_heater(CHAMBER_INDEX, no_wait_for_cooling);
   }
 
 #endif // HAS_TEMP_CHAMBER

--- a/MK4duo/src/gcode/temperature/m192.h
+++ b/MK4duo/src/gcode/temperature/m192.h
@@ -41,7 +41,7 @@
     bool no_wait_for_heating = parser.seen('S');
     if (no_wait_for_heating || parser.seen('R')) heaters[COOLER_INDEX].setTarget(parser.value_celsius());
 
-    printer.wait_cooler(no_wait_for_heating);
+    thermalManager.wait_heater(COOLER_INDEX, no_wait_for_cooling);
   }
 
 #endif // HAS_TEMP_COOLER

--- a/MK4duo/src/sanitycheck.h
+++ b/MK4duo/src/sanitycheck.h
@@ -1643,12 +1643,22 @@ static_assert(1 >= 0
   #endif
 #endif
 
-#if DISABLED(SDSUPPORT)
-  #if ENABLED(SD_SETTINGS)
-    #error DEPENDENCY ERROR: You have to enable SDSUPPORT to use SD_SETTINGS
-  #endif
-  #if ENABLED(EEPROM_SETTINGS) && ENABLED(EEPROM_SD)
+/**
+ * SDSUPPORT test
+ */
+#if ENABLED(SD_SETTINGS) && DISABLED(SDSUPPORT)
+  #error DEPENDENCY ERROR: You have to enable SDSUPPORT to use SD_SETTINGS
+#endif
+
+/**
+ * EEPROM test
+ */
+#if ENABLED(EEPROM_SETTINGS)
+  #if ENABLED(EEPROM_SD) && DISABLED(SDSUPPORT)
     #error DEPENDENCY ERROR: You have to enable SDSUPPORT to use EEPROM_SETTINGS
+  #endif
+  #if DISABLED(I2C_EEPROM) && DISABLED(SPI_EEPROM)
+    #error DEPENDENCY ERROR: Your board has no EEPROM support. Please disable EEPROM_SETTINGS!
   #endif
 #endif
 

--- a/MK4duo/src/sd/SDFat.cpp
+++ b/MK4duo/src/sd/SDFat.cpp
@@ -670,7 +670,9 @@ uint8_t SdBaseFile::lsRecursive(SdBaseFile* parent, uint8_t level, char* findFil
   dir_t *p = NULL;
   //uint8_t cnt=0;
   //char *oldpathend = pathend;
-  bool firstFile = true;
+  #if ENABLED(JSON_OUTPUT)
+    bool firstFile = true;
+  #endif
 
   parent->rewind();
 
@@ -686,7 +688,7 @@ uint8_t SdBaseFile::lsRecursive(SdBaseFile* parent, uint8_t level, char* findFil
           SERIAL_TXT(card.fileName);
           SERIAL_CHR('/');
         }
-        #ifdef JSON_OUTPUT
+        #if ENABLED(JSON_OUTPUT)
           if (isJson) {
             if (!firstFile) SERIAL_CHR(',');
             SERIAL_CHR('"'); SERIAL_CHR('*');
@@ -740,7 +742,7 @@ uint8_t SdBaseFile::lsRecursive(SdBaseFile* parent, uint8_t level, char* findFil
           SERIAL_TXT(card.fileName);
           SERIAL_CHR('/');
         }
-        #ifdef JSON_OUTPUT
+        #if ENABLED(JSON_OUTPUT)
           if (isJson) {
             if (!firstFile) SERIAL_CHR(',');
             SERIAL_CHR('"');
@@ -752,7 +754,7 @@ uint8_t SdBaseFile::lsRecursive(SdBaseFile* parent, uint8_t level, char* findFil
         #endif
         {
           SERIAL_TXT(card.tempLongFilename);
-          #ifdef SD_EXTENDED_DIR
+          #if ENABLED(SD_EXTENDED_DIR)
             SERIAL_MV(" ", (long) p->fileSize);
           #endif
           SERIAL_EOL();
@@ -776,7 +778,7 @@ void SdBaseFile::ls() {
   lsRecursive(&parent, 0, NULL, NULL, false);
 }
 
-#ifdef JSON_OUTPUT
+#if ENABLED(JSON_OUTPUT)
 void SdBaseFile::lsJSON() {
   SdBaseFile parent;
   rewind();
@@ -842,7 +844,7 @@ bool SdBaseFile::make83Name(const char* str, uint8_t* name, const char** ptr) {
     }
     else {
       // illegal FAT characters
-      #ifdef ARDUINO_ARCH_AVR
+      #if ENABLED(ARDUINO_ARCH_AVR)
         // store chars in flash
         PGM_P p = PSTR("|<>^+=?/[];,*\"\\");
         uint8_t b;

--- a/MK4duo/src/sd/cardreader.cpp
+++ b/MK4duo/src/sd/cardreader.cpp
@@ -212,7 +212,7 @@
         SERIAL_EM(MSG_SD_FILE_SELECTED);
       }
 
-      for (int c = 0; c < sizeof(fileName); c++)
+      for (uint16_t c = 0; c < sizeof(fileName); c++)
         const_cast<char&>(fileName[c]) = '\0';
       strncpy(fileName, filename, strlen(filename));
 
@@ -345,7 +345,6 @@
             buffer_G92_Z[50],
             buffer_G92_E[50],
             buffer_SDpos[11],
-            temp[50],
             old_file_name[50];
 
       const char* restart_name_File = "restart.gcode";


### PR DESCRIPTION
Ciao Alberto,
c'è un warning che mi preoccupa un po' ma su cui non saprei intervenire, dice che in Temperature.cpp viene superato il limite superiore di un array, causando la lettura di dati che non appartengono a quell'array ma che sono localizzati in un'area di memoria immediatamente adiacente. Il che porta a leggere "valori spazzatura". Magari non c'è nessun problema, però ti consiglio di darci un'occhiata:

```
sketch/src/temperature/temperature.cpp: In static member function 'static void Temperature::set_current_temp_raw()':
sketch/src/temperature/temperature.cpp:288:78: warning: array subscript is above array bounds [-Warray-bounds]
   LOOP_HEATER() heaters[h].current_temperature_raw = HAL::AnalogInputValues[h];
                                                                              ^
```

HAL::AnalogInputValues ha dimensione ANALOG_INPUTS, non so in che modo questo valore sia legato al numero di heaters