### PR TITLE
delta: renamed defines and vars to make more meaning for tower adjustment (polar: radius and angle)

### DIFF
--- a/Documentation/Features.md
+++ b/Documentation/Features.md
@@ -232,19 +232,24 @@ M666 L view value in memory for Z-Probe Offset.
 
 For DELTA:
 M666 L   List all current configuration values , e.g.:
-Current Delta geometry values:
+Current Delta geometry/print values:
 * X (Endstop Adj): -3.05
 * Y (Endstop Adj): -1.83
 * Z (Endstop Adj): -2.69
-* P (Z-Probe Offset): X0.00 Y10.00 Z-5.60
-* A (Tower A Position Correction): -0.04
-* B (Tower B Position Correction): 0.05
-* C (Tower C Position Correction): -0.02
-* I (Tower A Radius Correction): 0.25
-* J (Tower B Radius Correction): -1.25
-* K (Tower C Radius Correction): -0.37
+* A (Tower A Diagonal Rod Correction): 0.04
+* B (Tower B Diagonal Rod Correction): 0.05
+* C (Tower C Diagonal Rod Correction): 0.00
+* I (Tower A Angle Correction): 0.25
+* J (Tower B Angle Correction): -1.25
+* K (Tower C Angle Correction): 0.00
+* U (Tower A Radius Correction): -0.04
+* V (Tower B Radius Correction): 0.05
+* W (Tower C Radius Correction): -0.02
 * R (Delta Radius): 109.60
 * D (Diagonal Rod Length): 224.59
+* S (Segments per Second): 200
+* O (Print Radius): 120.0
+* P (Probe radius): 100.0
 * H (Z-Height): 255.73
 
 All of these values can also be adjusted using the M666 command, e.g. to set the delta radius to 200mm, use:

--- a/MK4duo/Configuration_Delta.h
+++ b/MK4duo/Configuration_Delta.h
@@ -127,24 +127,24 @@
 #define DELTA_PRINTABLE_RADIUS 75.0         // mm
 
 // Endstop Offset Adjustment - All values are in mm and must be negative (to move down away from endstop switches) 
-#define TOWER_A_ENDSTOP_ADJ 0   // Front Left Tower
-#define TOWER_B_ENDSTOP_ADJ 0   // Front Right Tower
-#define TOWER_C_ENDSTOP_ADJ 0   // Rear Tower
+#define TOWER_A_ENDSTOP_ADJ  0.00  // Front Left Tower
+#define TOWER_B_ENDSTOP_ADJ  0.00  // Front Right Tower
+#define TOWER_C_ENDSTOP_ADJ  0.00  // Rear Tower
 
-// Tower Radius Adjustment - Adj x Degrees around delta radius (- move clockwise / + move anticlockwise)
-#define TOWER_A_RADIUS_ADJ 0    // Front Left Tower
-#define TOWER_B_RADIUS_ADJ 0    // Front Right Tower
-#define TOWER_C_RADIUS_ADJ 0    // Rear Tower
+// Tower Radius Adjustment - Adj x mm in/out from centre of printer (- move in / + move out)
+#define TOWER_A_RADIUS_ADJ   0.00  // Front Left Tower
+#define TOWER_B_RADIUS_ADJ   0.00  // Front Right Tower
+#define TOWER_C_RADIUS_ADJ   0.00  // Rear Tower
 
-// Tower Position Adjustment - Adj x mm in/out from centre of printer (- move in / + move out)
-#define TOWER_A_POSITION_ADJ 0  // Front Left Tower
-#define TOWER_B_POSITION_ADJ 0  // Front Right Tower
-#define TOWER_C_POSITION_ADJ 0  // Rear Tower
+// Tower Angular Adjustment - Adj x Degrees around delta radius (- move clockwise / + move anticlockwise)
+#define TOWER_A_ANGLE_ADJ    0.00  // Front Left Tower
+#define TOWER_B_ANGLE_ADJ    0.00  // Front Right Tower
+#define TOWER_C_ANGLE_ADJ    0.00  // Rear Tower
 
 // Diagonal Rod Adjustment - Adj diag rod for Tower by x mm from DELTA_DIAGONAL_ROD value
-#define TOWER_A_DIAGROD_ADJ 0   // Front Left Tower
-#define TOWER_B_DIAGROD_ADJ 0   // Front Right Tower
-#define TOWER_C_DIAGROD_ADJ 0   // Rear Tower
+#define TOWER_A_DIAGROD_ADJ  0.00  // Front Left Tower
+#define TOWER_B_DIAGROD_ADJ  0.00  // Front Right Tower
+#define TOWER_C_DIAGROD_ADJ  0.00  // Rear Tower
 /*****************************************************************************************/
 
 

--- a/MK4duo/plugin Repetier/marlineeprom.xml
+++ b/MK4duo/plugin Repetier/marlineeprom.xml
@@ -574,32 +574,32 @@
     <detect>M666.*C(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">X Tower Radius Adj.</description>
+    <description unit="[deg]">X Tower Angle Adj.</description>
     <set>M666 I@</set>
     <detect>M666.*I(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">Y Tower Radius Adj.</description>
+    <description unit="[deg]">Y Tower Angle Adj.</description>
     <set>M666 J@</set>
     <detect>M666.*J(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">Z Tower Radius Adj.</description>
+    <description unit="[deg]">Z Tower Angle Adj.</description>
     <set>M666 K@</set>
     <detect>M666.*K(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">X Tower Position Adj.</description>
+    <description unit="[mm]">X Tower Radius Adj.</description>
     <set>M666 U@</set>
     <detect>M666.*U(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">Y Tower Position Adj.</description>
+    <description unit="[mm]">Y Tower Radius Adj.</description>
     <set>M666 V@</set>
     <detect>M666.*V(-?\d*\.?\d*)</detect>
   </entry>
   <entry type="float">
-    <description unit="[unit]">Z Tower Position Adj.</description>
+    <description unit="[mm]">Z Tower Radius Adj.</description>
     <set>M666 W@</set>
     <detect>M666.*W(-?\d*\.?\d*)</detect>
   </entry>

--- a/MK4duo/src/eeprom/eeprom.cpp
+++ b/MK4duo/src/eeprom/eeprom.cpp
@@ -91,9 +91,9 @@
  *  M666  D               mechanics.delta_diagonal_rod          (float)
  *  M666  S               mechanics.delta_segments_per_second   (float)
  *  M666  H               mechanics.delta_height                (float)
- *  M666  ABC             mechanics.delta_tower_radius_adj      (float x3)
- *  M666  IJK             mechanics.delta_tower_pos_adj         (float x3)
- *  M666  UVW             mechanics.delta_diagonal_rod_adj      (float x3)
+ *  M666  ABC             mechanics.delta_diagonal_rod_adj      (float x3)
+ *  M666  IJK             mechanics.delta_tower_angle_adj       (float x3)
+ *  M666  UVW             mechanics.delta_tower_radius_adj      (float x3)
  *  M666  O               mechanics.delta_print_radius          (float)
  *  M666  P               mechanics.delta_probe_radius          (float)
  *
@@ -387,8 +387,8 @@ void EEPROM::Postprocess() {
       EEPROM_WRITE(mechanics.delta_diagonal_rod);
       EEPROM_WRITE(mechanics.delta_segments_per_second);
       EEPROM_WRITE(mechanics.delta_height);
+      EEPROM_WRITE(mechanics.delta_tower_angle_adj);
       EEPROM_WRITE(mechanics.delta_tower_radius_adj);
-      EEPROM_WRITE(mechanics.delta_tower_pos_adj);
       EEPROM_WRITE(mechanics.delta_diagonal_rod_adj);
       EEPROM_WRITE(mechanics.delta_print_radius);
       EEPROM_WRITE(mechanics.delta_probe_radius);
@@ -712,8 +712,8 @@ void EEPROM::Postprocess() {
         EEPROM_READ(mechanics.delta_diagonal_rod);
         EEPROM_READ(mechanics.delta_segments_per_second);
         EEPROM_READ(mechanics.delta_height);
+        EEPROM_READ(mechanics.delta_tower_angle_adj);
         EEPROM_READ(mechanics.delta_tower_radius_adj);
-        EEPROM_READ(mechanics.delta_tower_pos_adj);
         EEPROM_READ(mechanics.delta_diagonal_rod_adj);
         EEPROM_READ(mechanics.delta_print_radius);
         EEPROM_READ(mechanics.delta_probe_radius);
@@ -1287,19 +1287,19 @@ void EEPROM::Factory_Settings() {
       SERIAL_MV(" Z", LINEAR_UNIT(mechanics.delta_endstop_adj[C_AXIS]));
       SERIAL_EOL();
 
-      CONFIG_MSG_START("Geometry adjustment: ABC=TOWER_DIAGROD_ADJ, IJK=TOWER_RADIUS_ADJ, UVW=TOWER_POSITION_ADJ");
+      CONFIG_MSG_START("Geometry adjustment: ABC=TOWER_DIAGROD_ADJ, IJK=TOWER_ANGLE_ADJ, UVW=TOWER_RADIUS_ADJ");
       CONFIG_MSG_START("                     R=DELTA_RADIUS, D=DELTA_DIAGONAL_ROD, S=DELTA_SEGMENTS_PER_SECOND");
       CONFIG_MSG_START("                     O=DELTA_PRINTABLE_RADIUS, P=DELTA_PROBEABLE_RADIUS, H=DELTA_HEIGHT");
       SERIAL_SM(CFG, "  M666");
       SERIAL_MV(" A", LINEAR_UNIT(mechanics.delta_diagonal_rod_adj[0]), 3);
       SERIAL_MV(" B", LINEAR_UNIT(mechanics.delta_diagonal_rod_adj[1]), 3);
       SERIAL_MV(" C", LINEAR_UNIT(mechanics.delta_diagonal_rod_adj[2]), 3);
-      SERIAL_MV(" I", mechanics.delta_tower_radius_adj[0], 3);
-      SERIAL_MV(" J", mechanics.delta_tower_radius_adj[1], 3);
-      SERIAL_MV(" K", mechanics.delta_tower_radius_adj[2], 3);
-      SERIAL_MV(" U", LINEAR_UNIT(mechanics.delta_tower_pos_adj[0]), 3);
-      SERIAL_MV(" V", LINEAR_UNIT(mechanics.delta_tower_pos_adj[1]), 3);
-      SERIAL_MV(" W", LINEAR_UNIT(mechanics.delta_tower_pos_adj[2]), 3);
+      SERIAL_MV(" I", mechanics.delta_tower_angle_adj[0], 3);
+      SERIAL_MV(" J", mechanics.delta_tower_angle_adj[1], 3);
+      SERIAL_MV(" K", mechanics.delta_tower_angle_adj[2], 3);
+      SERIAL_MV(" U", LINEAR_UNIT(mechanics.delta_tower_radius_adj[0]), 3);
+      SERIAL_MV(" V", LINEAR_UNIT(mechanics.delta_tower_radius_adj[1]), 3);
+      SERIAL_MV(" W", LINEAR_UNIT(mechanics.delta_tower_radius_adj[2]), 3);
       SERIAL_MV(" R", LINEAR_UNIT(mechanics.delta_radius));
       SERIAL_MV(" D", LINEAR_UNIT(mechanics.delta_diagonal_rod));
       SERIAL_MV(" S", mechanics.delta_segments_per_second);

--- a/MK4duo/src/gcode/delta/m666.h
+++ b/MK4duo/src/gcode/delta/m666.h
@@ -36,18 +36,18 @@
    *    D = Diagonal Rod
    *    R = Delta Radius
    *    S = Segments per Second
-   *    A = Alpha (Tower 1) Diagonal Rod Adjust
-   *    B = Beta  (Tower 2) Diagonal Rod Adjust
-   *    C = Gamma (Tower 3) Diagonal Rod Adjust
-   *    I = Alpha (Tower 1) Tower Radius Adjust
-   *    J = Beta  (Tower 2) Tower Radius Adjust
-   *    K = Gamma (Tower 3) Tower Radius Adjust
-   *    U = Alpha (Tower 1) Tower Position Adjust
-   *    V = Beta  (Tower 2) Tower Position Adjust
-   *    W = Gamma (Tower 3) Tower Position Adjust
-   *    X = Alpha (Tower 1) Endstop Adjust
-   *    Y = Beta  (Tower 2) Endstop Adjust
-   *    Z = Gamma (Tower 3) Endstop Adjust
+   *    A = Tower A: Diagonal Rod Adjust
+   *    B = Tower B: Diagonal Rod Adjust
+   *    C = Tower C: Diagonal Rod Adjust
+   *    I = Tower A: Tower Angle Adjust
+   *    J = Tower B: Tower Angle Adjust
+   *    K = Tower C: Tower Angle Adjust
+   *    U = Tower A: Tower Radius Adjust
+   *    V = Tower B: Tower Radius Adjust
+   *    W = Tower C: Tower Radius Adjust
+   *    X = Tower A: Endstop Adjust
+   *    Y = Tower B: Endstop Adjust
+   *    Z = Tower C: Endstop Adjust
    *    O = Print radius
    *    P = Probe radius
    *    H = Z Height
@@ -66,12 +66,12 @@
     if (parser.seen('A')) mechanics.delta_diagonal_rod_adj[A_AXIS]  = parser.value_linear_units();
     if (parser.seen('B')) mechanics.delta_diagonal_rod_adj[B_AXIS]  = parser.value_linear_units();
     if (parser.seen('C')) mechanics.delta_diagonal_rod_adj[C_AXIS]  = parser.value_linear_units();
-    if (parser.seen('I')) mechanics.delta_tower_radius_adj[A_AXIS]  = parser.value_linear_units();
-    if (parser.seen('J')) mechanics.delta_tower_radius_adj[B_AXIS]  = parser.value_linear_units();
-    if (parser.seen('K')) mechanics.delta_tower_radius_adj[C_AXIS]  = parser.value_linear_units();
-    if (parser.seen('U')) mechanics.delta_tower_pos_adj[A_AXIS]     = parser.value_linear_units();
-    if (parser.seen('V')) mechanics.delta_tower_pos_adj[B_AXIS]     = parser.value_linear_units();
-    if (parser.seen('W')) mechanics.delta_tower_pos_adj[C_AXIS]     = parser.value_linear_units();
+    if (parser.seen('I')) mechanics.delta_tower_angle_adj[A_AXIS]   = parser.value_linear_units();
+    if (parser.seen('J')) mechanics.delta_tower_angle_adj[B_AXIS]   = parser.value_linear_units();
+    if (parser.seen('K')) mechanics.delta_tower_angle_adj[C_AXIS]   = parser.value_linear_units();
+    if (parser.seen('U')) mechanics.delta_tower_radius_adj[A_AXIS]  = parser.value_linear_units();
+    if (parser.seen('V')) mechanics.delta_tower_radius_adj[B_AXIS]  = parser.value_linear_units();
+    if (parser.seen('W')) mechanics.delta_tower_radius_adj[C_AXIS]  = parser.value_linear_units();
     if (parser.seen('O')) mechanics.delta_print_radius              = parser.value_linear_units();
     if (parser.seen('P')) mechanics.delta_probe_radius              = parser.value_linear_units();
 
@@ -91,12 +91,12 @@
       SERIAL_LMV(CFG, "A (Tower A Diagonal Rod Correction): ",  mechanics.delta_diagonal_rod_adj[0], 3);
       SERIAL_LMV(CFG, "B (Tower B Diagonal Rod Correction): ",  mechanics.delta_diagonal_rod_adj[1], 3);
       SERIAL_LMV(CFG, "C (Tower C Diagonal Rod Correction): ",  mechanics.delta_diagonal_rod_adj[2], 3);
-      SERIAL_LMV(CFG, "I (Tower A Radius Correction): ",        mechanics.delta_tower_radius_adj[0], 3);
-      SERIAL_LMV(CFG, "J (Tower B Radius Correction): ",        mechanics.delta_tower_radius_adj[1], 3);
-      SERIAL_LMV(CFG, "K (Tower C Radius Correction): ",        mechanics.delta_tower_radius_adj[2], 3);
-      SERIAL_LMV(CFG, "U (Tower A Position Correction): ",      mechanics.delta_tower_pos_adj[0], 3);
-      SERIAL_LMV(CFG, "V (Tower B Position Correction): ",      mechanics.delta_tower_pos_adj[1], 3);
-      SERIAL_LMV(CFG, "W (Tower C Position Correction): ",      mechanics.delta_tower_pos_adj[2], 3);
+      SERIAL_LMV(CFG, "I (Tower A Angle Correction): ",         mechanics.delta_tower_angle_adj[0], 3);
+      SERIAL_LMV(CFG, "J (Tower B Angle Correction): ",         mechanics.delta_tower_angle_adj[1], 3);
+      SERIAL_LMV(CFG, "K (Tower C Angle Correction): ",         mechanics.delta_tower_angle_adj[2], 3);
+      SERIAL_LMV(CFG, "U (Tower A Radius Correction): ",        mechanics.delta_tower_radius_adj[0], 3);
+      SERIAL_LMV(CFG, "V (Tower B Radius Correction): ",        mechanics.delta_tower_radius_adj[1], 3);
+      SERIAL_LMV(CFG, "W (Tower C Radius Correction): ",        mechanics.delta_tower_radius_adj[2], 3);
       SERIAL_LMV(CFG, "R (Delta Radius): ",                     mechanics.delta_radius, 4);
       SERIAL_LMV(CFG, "D (Diagonal Rod Length): ",              mechanics.delta_diagonal_rod, 4);
       SERIAL_LMV(CFG, "S (Delta Segments per second): ",        mechanics.delta_segments_per_second);

--- a/MK4duo/src/lcd/ultralcd.cpp
+++ b/MK4duo/src/lcd/ultralcd.cpp
@@ -1956,9 +1956,9 @@ void kill_screen(const char* lcd_msg) {
       MENU_ITEM_EDIT(float43, "Ez", &mechanics.delta_endstop_adj[C_AXIS], -5.0, 0.0);
       MENU_ITEM_EDIT(float52, MSG_DELTA_DIAG_ROG, &mechanics.delta_diagonal_rod, DELTA_DIAGONAL_ROD - 5.0, DELTA_DIAGONAL_ROD + 5.0);
       MENU_ITEM_EDIT(float52, MSG_DELTA_RADIUS, &mechanics.delta_radius, DELTA_RADIUS - 5.0, DELTA_RADIUS + 5.0);
-      MENU_ITEM_EDIT(float43, "Tx", &mechanics.delta_tower_radius_adj[A_AXIS], -5.0, 5.0);
-      MENU_ITEM_EDIT(float43, "Ty", &mechanics.delta_tower_radius_adj[B_AXIS], -5.0, 5.0);
-      MENU_ITEM_EDIT(float43, "Tz", &mechanics.delta_tower_radius_adj[C_AXIS], -5.0, 5.0);
+      MENU_ITEM_EDIT(float43, "Tx", &mechanics.delta_tower_angle_adj[A_AXIS], -5.0, 5.0);
+      MENU_ITEM_EDIT(float43, "Ty", &mechanics.delta_tower_angle_adj[B_AXIS], -5.0, 5.0);
+      MENU_ITEM_EDIT(float43, "Tz", &mechanics.delta_tower_angle_adj[C_AXIS], -5.0, 5.0);
       END_MENU();
     }
 

--- a/MK4duo/src/mechanics/delta_mechanics.cpp
+++ b/MK4duo/src/mechanics/delta_mechanics.cpp
@@ -43,12 +43,12 @@
     delta_endstop_adj[A_AXIS]       = (float)TOWER_A_ENDSTOP_ADJ;
     delta_endstop_adj[B_AXIS]       = (float)TOWER_B_ENDSTOP_ADJ;
     delta_endstop_adj[C_AXIS]       = (float)TOWER_C_ENDSTOP_ADJ;
+    delta_tower_angle_adj[A_AXIS]   = (float)TOWER_A_ANGLE_ADJ;
+    delta_tower_angle_adj[B_AXIS]   = (float)TOWER_B_ANGLE_ADJ;
+    delta_tower_angle_adj[C_AXIS]   = (float)TOWER_C_ANGLE_ADJ;
     delta_tower_radius_adj[A_AXIS]  = (float)TOWER_A_RADIUS_ADJ;
     delta_tower_radius_adj[B_AXIS]  = (float)TOWER_B_RADIUS_ADJ;
     delta_tower_radius_adj[C_AXIS]  = (float)TOWER_C_RADIUS_ADJ;
-    delta_tower_pos_adj[A_AXIS]     = (float)TOWER_A_POSITION_ADJ;
-    delta_tower_pos_adj[B_AXIS]     = (float)TOWER_B_POSITION_ADJ;
-    delta_tower_pos_adj[C_AXIS]     = (float)TOWER_C_POSITION_ADJ;
     delta_diagonal_rod_adj[A_AXIS]  = (float)TOWER_A_DIAGROD_ADJ;
     delta_diagonal_rod_adj[B_AXIS]  = (float)TOWER_B_DIAGROD_ADJ;
     delta_diagonal_rod_adj[C_AXIS]  = (float)TOWER_C_DIAGROD_ADJ;
@@ -375,12 +375,12 @@
     delta_diagonal_rod_2[C_AXIS] = sq(delta_diagonal_rod + delta_diagonal_rod_adj[C_AXIS]);
 
     // Effective X/Y positions of the three vertical towers.
-    towerX[A_AXIS] = COS(RADIANS(210 + delta_tower_radius_adj[A_AXIS])) * (delta_radius + delta_tower_pos_adj[A_AXIS]); // front left tower
-    towerY[A_AXIS] = SIN(RADIANS(210 + delta_tower_radius_adj[A_AXIS])) * (delta_radius + delta_tower_pos_adj[A_AXIS]);
-    towerX[B_AXIS] = COS(RADIANS(330 + delta_tower_radius_adj[B_AXIS])) * (delta_radius + delta_tower_pos_adj[B_AXIS]); // front right tower
-    towerY[B_AXIS] = SIN(RADIANS(330 + delta_tower_radius_adj[B_AXIS])) * (delta_radius + delta_tower_pos_adj[B_AXIS]);
-    towerX[C_AXIS] = COS(RADIANS( 90 + delta_tower_radius_adj[C_AXIS])) * (delta_radius + delta_tower_pos_adj[C_AXIS]); // back middle tower
-    towerY[C_AXIS] = SIN(RADIANS( 90 + delta_tower_radius_adj[C_AXIS])) * (delta_radius + delta_tower_pos_adj[C_AXIS]);
+    towerX[A_AXIS] = COS(RADIANS(210.f + delta_tower_angle_adj[A_AXIS])) * (delta_radius + delta_tower_radius_adj[A_AXIS]); // front left tower
+    towerY[A_AXIS] = SIN(RADIANS(210.f + delta_tower_angle_adj[A_AXIS])) * (delta_radius + delta_tower_radius_adj[A_AXIS]);
+    towerX[B_AXIS] = COS(RADIANS(330.f + delta_tower_angle_adj[B_AXIS])) * (delta_radius + delta_tower_radius_adj[B_AXIS]); // front right tower
+    towerY[B_AXIS] = SIN(RADIANS(330.f + delta_tower_angle_adj[B_AXIS])) * (delta_radius + delta_tower_radius_adj[B_AXIS]);
+    towerX[C_AXIS] = COS(RADIANS( 90.f + delta_tower_angle_adj[C_AXIS])) * (delta_radius + delta_tower_radius_adj[C_AXIS]); // back middle tower
+    towerY[C_AXIS] = SIN(RADIANS( 90.f + delta_tower_angle_adj[C_AXIS])) * (delta_radius + delta_tower_radius_adj[C_AXIS]);
 
     Xbc = towerX[C_AXIS] - towerX[B_AXIS];
     Xca = towerX[A_AXIS] - towerX[C_AXIS];
@@ -947,9 +947,9 @@
       SERIAL_MV(" height ", delta_height, 3);
       SERIAL_MV(" diagonal rod ", delta_diagonal_rod, 3);
       SERIAL_MV(" delta radius ", delta_radius, 3);
-      SERIAL_MV(" Towers radius correction I", delta_tower_radius_adj[A_AXIS], 2);
-      SERIAL_MV(" J", delta_tower_radius_adj[B_AXIS], 2);
-      SERIAL_MV(" K", delta_tower_radius_adj[C_AXIS], 2);
+      SERIAL_MV(" Towers angle correction I", delta_tower_angle_adj[A_AXIS], 2);
+      SERIAL_MV(" J", delta_tower_angle_adj[B_AXIS], 2);
+      SERIAL_MV(" K", delta_tower_angle_adj[C_AXIS], 2);
       SERIAL_EOL();
 
       endstops.enable(true);
@@ -1042,8 +1042,8 @@
             },
             dr_old = delta_radius,
             dh_old = delta_height,
-            alpha_old = delta_tower_radius_adj[A_AXIS],
-            beta_old = delta_tower_radius_adj[B_AXIS];
+            alpha_old = delta_tower_angle_adj[A_AXIS],
+            beta_old = delta_tower_angle_adj[B_AXIS];
 
       if (!_1p_calibration) {  // test if the outer radius is reachable
         const float circles = (_7p_quadruple_circle ? 1.5 :
@@ -1162,8 +1162,8 @@
             COPY_ARRAY(e_old, delta_endstop_adj);
             dr_old = delta_radius;
             dh_old = delta_height;
-            alpha_old = delta_tower_radius_adj[A_AXIS];
-            beta_old = delta_tower_radius_adj[B_AXIS];
+            alpha_old = delta_tower_angle_adj[A_AXIS];
+            beta_old = delta_tower_angle_adj[B_AXIS];
           }
 
           float e_delta[XYZ] = { 0.0 }, r_delta = 0.0, t_alpha = 0.0, t_beta = 0.0;
@@ -1224,8 +1224,8 @@
 
           LOOP_XYZ(axis) delta_endstop_adj[axis] += e_delta[axis];
           delta_radius += r_delta;
-          delta_tower_radius_adj[A_AXIS] += t_alpha;
-          delta_tower_radius_adj[B_AXIS] += t_beta;
+          delta_tower_angle_adj[A_AXIS] += t_alpha;
+          delta_tower_angle_adj[B_AXIS] += t_beta;
 
           // adjust delta_height and endstops by the max amount
           const float z_temp = MAX3(delta_endstop_adj[A_AXIS], delta_endstop_adj[B_AXIS], delta_endstop_adj[C_AXIS]);
@@ -1238,8 +1238,8 @@
           COPY_ARRAY(delta_endstop_adj, e_old);
           delta_radius = dr_old;
           delta_height = dh_old;
-          delta_tower_radius_adj[A_AXIS] = alpha_old;
-          delta_tower_radius_adj[B_AXIS] = beta_old;
+          delta_tower_angle_adj[A_AXIS] = alpha_old;
+          delta_tower_angle_adj[B_AXIS] = beta_old;
 
           recalc_delta_settings();
         }
@@ -1347,9 +1347,9 @@
     SERIAL_EOL();
     if (tower_angles) {
       SERIAL_MSG(".Tower angle:   ");
-      print_signed_float(PSTR("Tx"), delta_tower_radius_adj[A_AXIS]);
-      print_signed_float(PSTR("Ty"), delta_tower_radius_adj[B_AXIS]);
-      print_signed_float(PSTR("Tz"), delta_tower_radius_adj[C_AXIS]);
+      print_signed_float(PSTR("Tx"), delta_tower_angle_adj[A_AXIS]);
+      print_signed_float(PSTR("Ty"), delta_tower_angle_adj[B_AXIS]);
+      print_signed_float(PSTR("Tz"), delta_tower_angle_adj[C_AXIS]);
       SERIAL_EOL();
     }
   }
@@ -1379,13 +1379,13 @@
         break;
 
       case 4:
-        hiParams.delta_tower_radius_adj[A_AXIS] += perturb;
-        loParams.delta_tower_radius_adj[A_AXIS] -= perturb;
+        hiParams.delta_tower_angle_adj[A_AXIS] += perturb;
+        loParams.delta_tower_angle_adj[A_AXIS] -= perturb;
         break;
 
       case 5:
-        hiParams.delta_tower_radius_adj[B_AXIS] += perturb;
-        loParams.delta_tower_radius_adj[B_AXIS] -= perturb;
+        hiParams.delta_tower_angle_adj[B_AXIS] += perturb;
+        loParams.delta_tower_angle_adj[B_AXIS] -= perturb;
         break;
 
       case 6:
@@ -1429,8 +1429,8 @@
       delta_radius += v[3];
 
       if (numFactors >= 6) {
-        delta_tower_radius_adj[A_AXIS] += v[4];
-        delta_tower_radius_adj[B_AXIS] += v[5];
+        delta_tower_angle_adj[A_AXIS] += v[4];
+        delta_tower_angle_adj[B_AXIS] += v[5];
 
         if (numFactors == 7) delta_diagonal_rod += v[6];
 

--- a/MK4duo/src/mechanics/delta_mechanics.h
+++ b/MK4duo/src/mechanics/delta_mechanics.h
@@ -49,8 +49,8 @@
             delta_clip_start_height     = 0.0,
             delta_diagonal_rod_adj[ABC] = { 0.0 },
             delta_endstop_adj[ABC]      = { 0.0 },
-            delta_tower_radius_adj[ABC] = { 0.0 },
-            delta_tower_pos_adj[ABC]    = { 0.0 };
+            delta_tower_angle_adj[ABC]  = { 0.0 },
+            delta_tower_radius_adj[ABC] = { 0.0 };
 
       #if HAS_DELTA_AUTO_CALIBRATION
         bool g33_in_progress = false;

--- a/MK4duo/src/sanitycheck.h
+++ b/MK4duo/src/sanitycheck.h
@@ -1430,15 +1430,6 @@ static_assert(1 >= 0
   #if DISABLED(TOWER_C_ENDSTOP_ADJ)
     #error DEPENDENCY ERROR: Missing setting TOWER_C_ENDSTOP_ADJ
   #endif
-  #if DISABLED(TOWER_A_POSITION_ADJ)
-    #error DEPENDENCY ERROR: Missing setting TOWER_A_POSITION_ADJ
-  #endif
-  #if DISABLED(TOWER_B_POSITION_ADJ)
-    #error DEPENDENCY ERROR: Missing setting TOWER_B_POSITION_ADJ
-  #endif
-  #if DISABLED(TOWER_C_POSITION_ADJ)
-    #error DEPENDENCY ERROR: Missing setting TOWER_C_POSITION_ADJ
-  #endif
   #if DISABLED(TOWER_A_RADIUS_ADJ)
     #error DEPENDENCY ERROR: Missing setting TOWER_A_RADIUS_ADJ
   #endif
@@ -1447,6 +1438,15 @@ static_assert(1 >= 0
   #endif
   #if DISABLED(TOWER_C_RADIUS_ADJ)
     #error DEPENDENCY ERROR: Missing setting TOWER_C_RADIUS_ADJ
+  #endif
+  #if DISABLED(TOWER_A_ANGLE_ADJ)
+    #error DEPENDENCY ERROR: Missing setting TOWER_A_ANGLE_ADJ
+  #endif
+  #if DISABLED(TOWER_B_ANGLE_ADJ)
+    #error DEPENDENCY ERROR: Missing setting TOWER_B_ANGLE_ADJ
+  #endif
+  #if DISABLED(TOWER_C_ANGLE_ADJ)
+    #error DEPENDENCY ERROR: Missing setting TOWER_C_ANGLE_ADJ
   #endif
   #if DISABLED(TOWER_A_DIAGROD_ADJ)
     #error DEPENDENCY ERROR: Missing setting TOWER_A_DIAGROD_ADJ


### PR DESCRIPTION
renamed defines and variables to have polar representation names and not from cartesian (position), which is confusing for user:

TOWER_X_RADIUS_ADJ  ->  TOWER_X_ANGLE_ADJ
TOWER_X_POSITION_ADJ  ->  TOWER_X_RADIUS_ADJ
where X stands for A, B and C tower

delta_tower_radius_adj  ->  delta_tower_angle_adj
delta_tower_pos_adj  ->  delta_tower_radius_adj

also updated serial output, comments and doc