### PR TITLE
Supporto completo (o quasi) a SCARA

### DIFF
--- a/MK4duo/src/commands/parser.cpp
+++ b/MK4duo/src/commands/parser.cpp
@@ -39,8 +39,9 @@
 
 char *GCodeParser::command_ptr,
      *GCodeParser::string_arg,
-     *GCodeParser::value_ptr;
-char  GCodeParser::command_letter;
+     *GCodeParser::value_ptr,
+      GCodeParser::command_letter;
+
 uint16_t GCodeParser::codenum;
 
 #if USE_GCODE_SUBCODES

--- a/MK4duo/src/gcode/calibrate/g42.h
+++ b/MK4duo/src/gcode/calibrate/g42.h
@@ -64,7 +64,12 @@
       const float fval = parser.linearval('F');
       if (fval > 0.0) mechanics.feedrate_mm_s = MMM_TO_MMS(fval);
 
-      mechanics.prepare_move_to_destination();
+      // SCARA kinematic has "safe" XY raw moves
+      #if IS_SCARA
+        mechanics.prepare_uninterpolated_move_to_destination();
+      #else
+        mechanics.prepare_move_to_destination();
+      #endif
 
     }
   }

--- a/MK4duo/src/gcode/gcode.h
+++ b/MK4duo/src/gcode/gcode.h
@@ -176,6 +176,7 @@
 
 // Scara Commands
 #include "scara/m360_m364.h"
+#include "scara/m665.h"
 
 // SDCard Commands
 #include "sdcard/sdcard.h"

--- a/MK4duo/src/gcode/geometry/m206.h
+++ b/MK4duo/src/gcode/geometry/m206.h
@@ -44,7 +44,12 @@
       if (parser.seen('P')) set_home_offset(Y_AXIS, parser.value_linear_units()); // Psi
     #endif
 
-    mechanics.sync_plan_position();
+    #if IS_SCARA
+      mechanics.sync_plan_position_kinematic();
+    #else
+      mechanics.sync_plan_position();
+    #endif
+
     mechanics.report_current_position();
   }
 

--- a/MK4duo/src/gcode/motion/g2_g3.h
+++ b/MK4duo/src/gcode/motion/g2_g3.h
@@ -52,7 +52,7 @@
  *    G2 I10           ; CW circle centered at X+10
  *    G3 X20 Y12 R14   ; CCW circle with r=14 ending at X20 Y12
  */
-#if ENABLED(ARC_SUPPORT)
+#if ENABLED(ARC_SUPPORT) && !IS_SCARA
 
   #define CODE_G2
   #define CODE_G3
@@ -137,4 +137,4 @@
   inline void gcode_G2(void) { gcode_G2_G3(true); }
   inline void gcode_G3(void) { gcode_G2_G3(false); }
 
-#endif // ARC_SUPPORT
+#endif // ARC_SUPPORT && !IS_SCARA

--- a/MK4duo/src/gcode/scara/m665.h
+++ b/MK4duo/src/gcode/scara/m665.h
@@ -62,6 +62,7 @@
       else if (sumBTY > 1) {
         SERIAL_EM("Only one of B, T, or Y is allowed.");
         return;
+      }
     #endif // WORKSPACE_OFFSETS
   }
 #endif // IS_SCARA

--- a/MK4duo/src/gcode/scara/m665.h
+++ b/MK4duo/src/gcode/scara/m665.h
@@ -1,0 +1,67 @@
+/**
+ * MK4duo Firmware for 3D Printer, Laser and CNC
+ *
+ * Based on Marlin, Sprinter and grbl
+ * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
+ * Copyright (C) 2013 Alberto Cotronei @MagoKimbra
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+/**
+ * mcode
+ *
+ * Copyright (C) 2017 Alberto Cotronei @MagoKimbra
+ */
+
+#if IS_SCARA
+
+  #define CODE_M665
+
+  /**
+   * M665: Set SCARA settings
+   *
+   * Parameters:
+   *
+   *   S[segments-per-second] - Segments-per-second
+   *   P[theta-psi-offset]    - Theta-Psi offset, added to the shoulder (A/X) angle
+   *   T[theta-offset]        - Theta     offset, added to the elbow    (B/Y) angle
+   *
+   *   A, P, and X are all aliases for the shoulder angle
+   *   B, T, and Y are all aliases for the elbow angle
+   */
+  inline void gcode_M665() {
+    if (parser.seen('S')) mechanics.delta_segments_per_second = parser.value_float();
+
+    #if ENABLED(WORKSPACE_OFFSETS)
+      const bool hasA = parser.seen('A'), hasP = parser.seen('P'), hasX = parser.seen('X');
+      const uint8_t sumAPX = hasA + hasP + hasX;
+      if (sumAPX == 1)
+        mechanics.home_offset[A_AXIS] = parser.value_float();
+      else if (sumAPX > 1) {
+        SERIAL_EM("Only one of A, P, or X is allowed.");
+        return;
+      }
+
+      const bool hasB = parser.seen('B'), hasT = parser.seen('T'), hasY = parser.seen('Y');
+      const uint8_t sumBTY = hasB + hasT + hasY;
+      if (sumBTY == 1)
+        mechanics.home_offset[B_AXIS] = parser.value_float();
+      else if (sumBTY > 1) {
+        SERIAL_EM("Only one of B, T, or Y is allowed.");
+        return;
+    #endif // WORKSPACE_OFFSETS
+  }
+#endif // IS_SCARA

--- a/MK4duo/src/mechanics/cartesian_mechanics.h
+++ b/MK4duo/src/mechanics/cartesian_mechanics.h
@@ -154,7 +154,7 @@
       /**
        *  Home axis
        */
-      void homeaxis(const AxisEnum axis);
+      void homeaxis(const AxisEnum axis) override;
 
       /**
        * Prepare a linear move in a Cartesian setup.

--- a/MK4duo/src/mechanics/core_mechanics.h
+++ b/MK4duo/src/mechanics/core_mechanics.h
@@ -104,7 +104,7 @@
       /**
        *  Home axis
        */
-      void homeaxis(const AxisEnum axis);
+      void homeaxis(const AxisEnum axis) override;
 
       /**
        * Prepare a linear move in a Cartesian setup.

--- a/MK4duo/src/mechanics/delta_mechanics.h
+++ b/MK4duo/src/mechanics/delta_mechanics.h
@@ -160,7 +160,7 @@
       /**
        *  Home axis
        */
-      void homeaxis(const AxisEnum axis);
+      void homeaxis(const AxisEnum axis) override;
 
       /**
        * Calculate delta, start a line, and set current_position to destination

--- a/MK4duo/src/mechanics/mechanics.cpp
+++ b/MK4duo/src/mechanics/mechanics.cpp
@@ -326,6 +326,11 @@ void Mechanics::do_homing_move(const AxisEnum axis, const float distance, const 
     }
   #endif
 
+  #if HOMING_Z_WITH_PROBE && ENABLED(BLTOUCH)
+    const bool deploy_bltouch = (axis == Z_AXIS && distance < 0.0);
+    if (deploy_bltouch) probe.set_bltouch_deployed(true);
+  #endif
+
   #if QUIET_PROBING
     if (axis == Z_AXIS) probe.probing_pause(true);
   #endif
@@ -341,6 +346,10 @@ void Mechanics::do_homing_move(const AxisEnum axis, const float distance, const 
 
   #if QUIET_PROBING
     if (axis == Z_AXIS) probe.probing_pause(false);
+  #endif
+
+  #if HOMING_Z_WITH_PROBE && ENABLED(BLTOUCH)
+    if (deploy_bltouch) probe.set_bltouch_deployed(false);
   #endif
 
   endstops.hit_on_purpose();

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -203,7 +203,6 @@ class Mechanics {
     virtual void set_position_mm(const float position[NUM_AXIS]);
     FORCE_INLINE void set_z_position_mm(const float &z) { set_position_mm(AxisEnum(Z_AXIS), z); }
     FORCE_INLINE void set_e_position_mm(const float &e) { set_position_mm(AxisEnum(E_AXIS), e); }
-    virtual void set_position_mm_kinematic(const float position[NUM_AXIS]);
 
     /**
      * Get the stepper positions in the cartes[] array.
@@ -285,7 +284,6 @@ class Mechanics {
      */
             void sync_plan_position();
             void sync_plan_position_e();
-    virtual void sync_plan_position_kinematic();
 
     /**
      * Recalculate the steps/s^2 acceleration rates, based on the mm/s^2

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -342,6 +342,12 @@ class Mechanics {
 
     float get_homing_bump_feedrate(const AxisEnum axis);
 
+  private: /** Private Function */
+  
+    /**
+     *  Home axis
+     */
+    virtual void homeaxis(const AxisEnum axis) = 0;
 };
 
 #if IS_CARTESIAN

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -203,6 +203,7 @@ class Mechanics {
     virtual void set_position_mm(const float position[NUM_AXIS]);
     FORCE_INLINE void set_z_position_mm(const float &z) { set_position_mm(AxisEnum(Z_AXIS), z); }
     FORCE_INLINE void set_e_position_mm(const float &e) { set_position_mm(AxisEnum(E_AXIS), e); }
+    virtual void set_position_mm_kinematic(const float position[NUM_AXIS]);
 
     /**
      * Get the stepper positions in the cartes[] array.
@@ -282,8 +283,9 @@ class Mechanics {
      * Set the planner/stepper positions directly from current_position with
      * no kinematic translation. Used for homing axes and cartesian/core syncing.
      */
-    void sync_plan_position();
-    void sync_plan_position_e();
+            void sync_plan_position();
+            void sync_plan_position_e();
+    virtual void sync_plan_position_kinematic();
 
     /**
      * Recalculate the steps/s^2 acceleration rates, based on the mm/s^2
@@ -298,7 +300,7 @@ class Mechanics {
     /**
      * Home an individual linear axis
      */
-    void do_homing_move(const AxisEnum axis, const float distance, const float fr_mm_s=0.0);
+    virtual void do_homing_move(const AxisEnum axis, const float distance, const float fr_mm_s=0.0);
 
     /**
      * Report current position to host

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -282,8 +282,8 @@ class Mechanics {
      * Set the planner/stepper positions directly from current_position with
      * no kinematic translation. Used for homing axes and cartesian/core syncing.
      */
-            void sync_plan_position();
-            void sync_plan_position_e();
+    void sync_plan_position();
+    void sync_plan_position_e();
 
     /**
      * Recalculate the steps/s^2 acceleration rates, based on the mm/s^2

--- a/MK4duo/src/mechanics/mechanics.h
+++ b/MK4duo/src/mechanics/mechanics.h
@@ -303,7 +303,7 @@ class Mechanics {
     /**
      * Report current position to host
      */
-            void report_current_position();
+    virtual void report_current_position();
     virtual void report_current_position_detail();
 
     FORCE_INLINE void report_xyz(const float pos[XYZ]) { report_xyze(pos, 3); }

--- a/MK4duo/src/mechanics/scara_mechanics.cpp
+++ b/MK4duo/src/mechanics/scara_mechanics.cpp
@@ -540,7 +540,7 @@
    * Maths and first version by QHARLEY.
    * Integrated into Marlin and slightly restructured by Joachim Cerny.
    */
-  void Scara_Mechanics::inverse_kinematics(const float logical[XYZ]) {
+  void Scara_Mechanics::inverse_kinematics_SCARA(const float logical[XYZ]) {
 
     static float C2, S2, SK1, SK2, THETA, PSI;
 

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -63,6 +63,11 @@
       bool prepare_move_to_destination_mech_specific();
 
       /**
+       * Home an individual linear axis
+       */
+      void do_homing_move(const AxisEnum axis, const float distance, const float fr_mm_s=0.0) override;
+
+      /**
        * Calculate delta, start a line, and set current_position to destination
        */
       void prepare_uninterpolated_move_to_destination(const float fr_mm_s=0.0);
@@ -77,6 +82,9 @@
        * Callers must sync the planner position after calling this!
        */
       void set_axis_is_at_home(const AxisEnum axis);
+
+      void set_position_mm_kinematic(const float position[NUM_AXIS]) override;
+      void sync_plan_position_kinematic() override;
 
       void do_blocking_move_to(const float &lx, const float &ly, const float &lz, const float &fr_mm_s/*=0.0*/) override;
       bool position_is_reachable_raw_xy(const float &rx, const float &ry) override;

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -93,6 +93,7 @@
       #if MECH(MORGAN_SCARA)
         bool move_to_cal(uint8_t delta_a, uint8_t delta_b);
         void forward_kinematics_SCARA(const float &a, const float &b);
+        void inverse_kinematics_SCARA(const float logical[XYZ]);
       #endif
       
     private: /** Private Function */

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -94,7 +94,13 @@
         bool move_to_cal(uint8_t delta_a, uint8_t delta_b);
         void forward_kinematics_SCARA(const float &a, const float &b);
       #endif
-
+      
+    private: /** Private Function */
+    
+      /**
+       *  Home axis
+       */
+      void homeaxis(const AxisEnum axis) override;
   };
 
   extern Scara_Mechanics mechanics;

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -83,8 +83,8 @@
        */
       void set_axis_is_at_home(const AxisEnum axis);
 
-      void set_position_mm_kinematic(const float position[NUM_AXIS]) override;
-      void sync_plan_position_kinematic() override;
+      void set_position_mm_kinematic(const float position[NUM_AXIS]);
+      void sync_plan_position_kinematic();
 
       void do_blocking_move_to(const float &lx, const float &ly, const float &lz, const float &fr_mm_s/*=0.0*/) override;
       bool position_is_reachable_raw_xy(const float &rx, const float &ry) override;

--- a/MK4duo/src/mechanics/scara_mechanics.h
+++ b/MK4duo/src/mechanics/scara_mechanics.h
@@ -55,6 +55,14 @@
       void Init();
 
       /**
+       * Report current position to host
+       */
+      void report_current_position() override;
+      void report_current_position_detail() override;
+      
+      void get_cartesian_from_steppers() override;
+
+      /**
        * Prepare a linear move in a SCARA setup.
        *
        * This calls planner.buffer_line several times, adding

--- a/MK4duo/src/planner/planner.h
+++ b/MK4duo/src/planner/planner.h
@@ -154,7 +154,7 @@ class Planner {
 
     /**
      * Limit where 64bit math is necessary for acceleration calculation
- 	   */
+     */
     static uint32_t cutoff_long;
 
     #if ENABLED(LIN_ADVANCE)

--- a/MK4duo/src/stepper/stepper.cpp
+++ b/MK4duo/src/stepper/stepper.cpp
@@ -1493,7 +1493,7 @@ void Stepper::synchronize() { while (planner.blocks_queued()) printer.idle(); }
  * The input is based on the typical per-axis XYZ steps.
  * For CORE machines XYZ needs to be translated to ABC.
  *
- * This allows get_axis_position_mm to correctly
+ * This allows mechanics.get_axis_position_mm to correctly
  * derive the current XYZ position later on.
  */
 void Stepper::set_position(const long &a, const long &b, const long &c, const long &e) {

--- a/MK4duo/src/stepper/stepper.h
+++ b/MK4duo/src/stepper/stepper.h
@@ -117,7 +117,7 @@ class Stepper {
     // SCARA AB axes are in degrees, not mm
     //
     #if IS_SCARA
-      static FORCE_INLINE float get_axis_position_degrees(AxisEnum axis) { return get_axis_position_mm(axis); }
+      static FORCE_INLINE float get_axis_position_degrees(AxisEnum axis) { return mechanics.get_axis_position_mm(axis); }
     #endif
 
     //


### PR DESCRIPTION
Compilando per MORGAN_SCARA o MAKERARM_SCARA dà ancora alcuni errori: uno dovuto alla mancanza delle funzioni Transform e Home in scara_mechanics e un altro legato alla macro MACHINE_TYPE. Per il resto, ho confrontato le funzioni di Marlin 1.1.5 con MK4duo. E' probabile che abbia copiato qualcosa di Marlin che non va bene per MK4duo, quando hai tempo dacci un'occhiata.

C'è una funzione che ho dichiarato così:
`virtual void homeaxis(const AxisEnum axis) = 0;`
Quel " = 0;" è voluto, non è un errore: significa che la funzione è virtuale pura, ovvero in mechanics.cpp non appare l'implementazione di homeaxis e quindi le classi figlie sono costrette ad implementarla, pena un errore di compilazione.