### PR TITLE
Fix I2C and SPI eeprom

### DIFF
--- a/MK4duo/src/HAL/I2cEeprom.cpp
+++ b/MK4duo/src/HAL/I2cEeprom.cpp
@@ -27,7 +27,7 @@
 
 #include "../../MK4duo.h"
 
-#if ENABLED(I2C_EEPROM)
+#if ENABLED(EEPROM_SETTINGS) && ENABLED(I2C_EEPROM)
 
 // --------------------------------------------------------------------------
 // Includes

--- a/MK4duo/src/HAL/SpiEeprom.cpp
+++ b/MK4duo/src/HAL/SpiEeprom.cpp
@@ -27,7 +27,7 @@
 
 #include "../../MK4duo.h"
 
-#if ENABLED(SPI_EEPROM)
+#if ENABLED(EEPROM_SETTINGS) && ENABLED(SPI_EEPROM)
 
 #include "HAL.h"
 


### PR DESCRIPTION
I2C_EEPROM and SPI_EEPROM code loading is needed only if EEPROM_SETTINGS is enabled.