### PR TITLE
Fix G32

### DIFF
--- a/MK4duo/src/gcode/gcode.h
+++ b/MK4duo/src/gcode/gcode.h
@@ -170,7 +170,7 @@
 
 // Probe Commands
 #include "probe/g30.h"
-#include "probe/g31.h"
+#include "probe/g31_g32.h"
 #include "probe/g38.h"
 #include "probe/m401_m402.h"              // Lower e Raise probe
 #include "probe/m851.h"                   // Set probe offset

--- a/MK4duo/src/gcode/motion/g90.h
+++ b/MK4duo/src/gcode/motion/g90.h
@@ -29,6 +29,6 @@
 #define CODE_G90
 
 /**
- * G90: Assolute mode
+ * G90: Absolute mode
  */
 inline void gcode_G90(void) { printer.relative_mode = false; }

--- a/MK4duo/src/gcode/probe/g31_g32.h
+++ b/MK4duo/src/gcode/probe/g31_g32.h
@@ -29,13 +29,12 @@
 #if ENABLED(Z_PROBE_SLED)
 
   #define CODE_G31
+  #define CODE_G32
 
   /**
    * G31: Deploy the Z probe
    */
   inline void gcode_G31(void) { DEPLOY_PROBE(); }
-
-  #define G32
 
   /**
    * G32: Stow the Z probe


### PR DESCRIPTION
In g31.h there was "#define CODE_G31 and #define G32" (G32 was not inserted in the GCode_Table). Now it is "#define CODE_G31 and #define CODE_G32"