### PR TITLE
Added MKS 12864 OLED support to Ramps FD v2

### DIFF
--- a/MK4duo/src/boards/1404.h
+++ b/MK4duo/src/boards/1404.h
@@ -198,6 +198,4 @@
     #endif
   #endif
 #endif //ULTRA_LCD
-
-
 //@@@

--- a/MK4duo/src/boards/1404.h
+++ b/MK4duo/src/boards/1404.h
@@ -167,6 +167,17 @@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
+
+  #if ENABLED(MKS_12864OLED) || ENABLED(MKS_12864OLED_SSD1306)
+    #define LCD_PINS_DC     25
+    #define LCD_PINS_RS     27
+    // DOGM SPI LCD Support
+    #define DOGLCD_CS       16
+    #define DOGLCD_MOSI     17
+    #define DOGLCD_SCK      23
+    #define DOGLCD_A0       LCD_PINS_DC
+  #endif
+
   #if ENABLED(NEWPANEL)
     // ramps-fd lcd adaptor
     #define LCD_PINS_RS         16
@@ -187,4 +198,6 @@
     #endif
   #endif
 #endif //ULTRA_LCD
+
+
 //@@@


### PR DESCRIPTION
This PR is related to #385 and #369 . It turned out that the needed pin definitions were identical to those found in 33.h (RAMPS 1.4)