### PR TITLE
Board files cleanup

### DIFF
--- a/MK4duo/src/boards/10.h
+++ b/MK4duo/src/boards/10.h
@@ -159,7 +159,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define LCD_PINS_RS      18
 #define LCD_PINS_ENABLE  17
@@ -171,4 +170,3 @@
 #define BTN_EN2          10
 #define BTN_ENC          12  //the click
 //@@@
-

--- a/MK4duo/src/boards/100.h
+++ b/MK4duo/src/boards/100.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 /**
  * LCD / Controller

--- a/MK4duo/src/boards/11.h
+++ b/MK4duo/src/boards/11.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
 //@@@
-

--- a/MK4duo/src/boards/12.h
+++ b/MK4duo/src/boards/12.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
 //@@@
-

--- a/MK4duo/src/boards/13.h
+++ b/MK4duo/src/boards/13.h
@@ -156,6 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/1400.h
+++ b/MK4duo/src/boards/1400.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 8K of space
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1401.h
+++ b/MK4duo/src/boards/1401.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 8K of space
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1403.h
+++ b/MK4duo/src/boards/1403.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define MAX6675_SS_PIN             53
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1404.h
+++ b/MK4duo/src/boards/1404.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define MAX6675_SS_PIN             53
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1405.h
+++ b/MK4duo/src/boards/1405.h
@@ -166,7 +166,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define I2C_EEPROM
 #define E2END 0x2000

--- a/MK4duo/src/boards/1407.h
+++ b/MK4duo/src/boards/1407.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define EEPROM_I2C
 #define E2END 0x0FFF

--- a/MK4duo/src/boards/1411.h
+++ b/MK4duo/src/boards/1411.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 4K of space
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1412.h
+++ b/MK4duo/src/boards/1412.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 4K of space
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1413.h
+++ b/MK4duo/src/boards/1413.h
@@ -158,12 +158,11 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 4K of space
 #define EEPROM_I2C
 #define E2END 0xFFF
-#define MAX6675_SS_PIN            66 // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/1414.h
+++ b/MK4duo/src/boards/1414.h
@@ -158,12 +158,11 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 4K of space
 #define EEPROM_I2C
 #define E2END 0xFFF
-#define MAX6675_SS_PIN            66 // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/1433.h
+++ b/MK4duo/src/boards/1433.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define EEPROM_I2C
 #define E2END 0x2000

--- a/MK4duo/src/boards/1502.h
+++ b/MK4duo/src/boards/1502.h
@@ -166,7 +166,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #undef NUM_DIGITAL_PINS
 #define NUM_DIGITAL_PINS 111

--- a/MK4duo/src/boards/1503.h
+++ b/MK4duo/src/boards/1503.h
@@ -166,7 +166,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define NUM_DIGITAL_PINS 111
 #define SPI_CHAN_DAC 1

--- a/MK4duo/src/boards/1550.h
+++ b/MK4duo/src/boards/1550.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 // I2C EEPROM with 32K of space
 #define EEPROM_I2C

--- a/MK4duo/src/boards/1590.h
+++ b/MK4duo/src/boards/1590.h
@@ -168,7 +168,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #undef NUM_DIGITAL_PINS
 #define NUM_DIGITAL_PINS 108

--- a/MK4duo/src/boards/1705.h
+++ b/MK4duo/src/boards/1705.h
@@ -158,7 +158,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define EEPROM_SD
 #define MAX6675_SS_PIN    65

--- a/MK4duo/src/boards/2.h
+++ b/MK4duo/src/boards/2.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define LCD_PINS_RS NoPin
 #define LCD_PINS_ENABLE NoPin
@@ -172,4 +171,3 @@
 #define BLEN_B 1
 #define BLEN_A 0
 //@@@
-

--- a/MK4duo/src/boards/20.h
+++ b/MK4duo/src/boards/20.h
@@ -131,7 +131,7 @@
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
 //###FAN
-#define ORIG_FAN0_PIN              NoPin
+#define ORIG_FAN0_PIN              31
 #define ORIG_FAN1_PIN              NoPin
 #define ORIG_FAN2_PIN              NoPin
 #define ORIG_FAN3_PIN              NoPin
@@ -157,16 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define BOGUS_TEMPERATURE_FAILSAFE_OVERRIDE
-//@@@
-
-//###IF_BLOCKS
-#if (GEN7_VERSION >= 13)
-  // Gen7 v1.3 removed the fan pin
-  #define ORIG_FAN0_PIN NoPin
-#else
-  #define ORIG_FAN0_PIN 31
-#endif
 //@@@

--- a/MK4duo/src/boards/21.h
+++ b/MK4duo/src/boards/21.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define SLEEP_WAKE_PIN        26  // This feature still needs work
 #define PHOTOGRAPH_PIN        29

--- a/MK4duo/src/boards/22.h
+++ b/MK4duo/src/boards/22.h
@@ -156,6 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/243.h
+++ b/MK4duo/src/boards/243.h
@@ -157,7 +157,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -400,7 +402,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/3.h
+++ b/MK4duo/src/boards/3.h
@@ -113,7 +113,7 @@
 #define Z_STOP_PIN                 NoPin
 
 //###HEATER
-#define ORIG_HEATER_0_PIN          NoPin
+#define ORIG_HEATER_0_PIN          12
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
@@ -131,7 +131,7 @@
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
 //###FAN
-#define ORIG_FAN0_PIN              NoPin
+#define ORIG_FAN0_PIN              11
 #define ORIG_FAN1_PIN              NoPin
 #define ORIG_FAN2_PIN              NoPin
 #define ORIG_FAN3_PIN              NoPin
@@ -157,24 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
-//###IF_BLOCKS
-//#define RAMPS_V_1_0
-#if ENABLED(RAMPS_V_1_0)
-  #define ORIG_HEATER_0_PIN        12
-  #define ORIG_HEATER_BED_PIN      NoPin
-  #define ORIG_FAN0_PIN            11
-#else
-  #define ORIG_HEATER_0_PIN        10
-  #define ORIG_HEATER_BED_PIN       8
-  #define ORIG_FAN0_PIN             9
-#endif
-
-// SPI for Max6675 Thermocouple
-#if DISABLED(SDSUPPORT)
-  #define MAX6675_SS_PIN            66
-#else
-  #define MAX6675_SS_PIN            66
-#endif
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
 //@@@

--- a/MK4duo/src/boards/301.h
+++ b/MK4duo/src/boards/301.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define X_MS1_PIN 40
 #define X_MS2_PIN 41

--- a/MK4duo/src/boards/302.h
+++ b/MK4duo/src/boards/302.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN          9
 
-
 //###UNKNOWN_PINS
 // Microstepping pins - Mapping not from fastio.h (?)
 #define X_MS1_PIN           40

--- a/MK4duo/src/boards/303.h
+++ b/MK4duo/src/boards/303.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN          9
 
-
 //###UNKNOWN_PINS
 // Microstepping pins - Mapping not from fastio.h (?)
 #define X_MS1_PIN           40

--- a/MK4duo/src/boards/316.h
+++ b/MK4duo/src/boards/316.h
@@ -156,6 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/33.h
+++ b/MK4duo/src/boards/33.h
@@ -158,7 +158,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -401,7 +403,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/34.h
+++ b/MK4duo/src/boards/34.h
@@ -158,7 +158,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -401,7 +403,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/35.h
+++ b/MK4duo/src/boards/35.h
@@ -158,7 +158,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -401,7 +403,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/36.h
+++ b/MK4duo/src/boards/36.h
@@ -158,7 +158,9 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -401,7 +403,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/37.h
+++ b/MK4duo/src/boards/37.h
@@ -158,7 +158,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -401,7 +403,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/39.h
+++ b/MK4duo/src/boards/39.h
@@ -157,9 +157,8 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN              66  // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+#define MAX6675_SS_PIN              66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/40.h
+++ b/MK4duo/src/boards/40.h
@@ -143,7 +143,7 @@
 #define SERVO3_PIN                  4
 
 //###MISC
-#define ORIG_PS_ON_PIN             NoPin
+#define ORIG_PS_ON_PIN             12
 #define ORIG_BEEPER_PIN            NoPin
 #define LED_PIN                    13
 #define SDPOWER_PIN                NoPin
@@ -157,9 +157,7 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
-#define PS_ON_PIN                   12
 #define MAX6675_SS_PIN              66
 //@@@
 

--- a/MK4duo/src/boards/41.h
+++ b/MK4duo/src/boards/41.h
@@ -157,9 +157,8 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN            58 // Do not use pin 53 if there is even the remote possibility of using Display/SD card
+#define MAX6675_SS_PIN             58
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/431.h
+++ b/MK4duo/src/boards/431.h
@@ -157,7 +157,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN              66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -390,11 +392,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#if DISABLED(SDSUPPORT)
-  #define MAX6675_SS_PIN  66 // Do not use pin 53 if there is even the remote possibility of using Display/SD card
-#else
-  #define MAX6675_SS_PIN  66 // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
-#endif
 //@@@

--- a/MK4duo/src/boards/47.h
+++ b/MK4duo/src/boards/47.h
@@ -157,7 +157,9 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -399,12 +401,5 @@
   // white                BLUE-LED
   #define STAT_LED_BLUE_PIN 17
 
-#endif
-
-// SPI for Max6675 or Max31855 Thermocouple
-#if DISABLED(SDSUPPORT)
-  #define MAX6675_SS_PIN            66
-#else
-  #define MAX6675_SS_PIN            66
 #endif
 //@@@

--- a/MK4duo/src/boards/49.h
+++ b/MK4duo/src/boards/49.h
@@ -157,7 +157,9 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -313,11 +315,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#if DISABLED(SDSUPPORT)
-  #define MAX6675_SS_PIN            66
-#else
-  #define MAX6675_SS_PIN            66
-#endif
 //@@@

--- a/MK4duo/src/boards/5.h
+++ b/MK4duo/src/boards/5.h
@@ -156,15 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-
-//###IF_BLOCKS
-#if MOTHERBOARD == 5
-  #define ORIG_HEATER_BED_PIN  NoPin
-  #define ORIG_TEMP_BED_PIN    NoPin
-#else
-  #define ORIG_HEATER_BED_PIN   1
-  #define ORIG_TEMP_BED_PIN     0
-#endif
-//@@@

--- a/MK4duo/src/boards/53.h
+++ b/MK4duo/src/boards/53.h
@@ -157,7 +157,9 @@
 #define ORIG_LASER_PWR_PIN          5
 #define ORIG_LASER_PWM_PIN          6
 
-
+//###UNKNOWN_PINS
+#define MAX6675_SS_PIN             66
+//@@@
 
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
@@ -400,7 +402,4 @@
   #endif // NEWPANEL
 
 #endif // ULTRA_LCD
-
-// SPI for Max6675 or Max31855 Thermocouple
-#define MAX6675_SS_PIN         66
 //@@@

--- a/MK4duo/src/boards/6.h
+++ b/MK4duo/src/boards/6.h
@@ -116,7 +116,7 @@
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
-#define ORIG_HEATER_BED_PIN        NoPin
+#define ORIG_HEATER_BED_PIN        14
 #define ORIG_HEATER_CHAMBER_PIN    NoPin
 #define ORIG_COOLER_PIN            NoPin
 
@@ -156,39 +156,7 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
-#if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
-  #define ORIG_FAN0_PIN           4
-  #if MB(MELZI)
-    #define LED_PIN             27
-  #elif MB(STB_11)
-    #define LCD_BACKLIGHT_PIN   17
-  #endif
-#endif
-
-#if ENABLED(SANGUINOLOLU_V_1_2)
-
-  #define ORIG_HEATER_BED_PIN   12
-  #define ORIG_X_ENABLE_PIN     14
-  #define ORIG_Y_ENABLE_PIN     14
-  #define ORIG_Z_ENABLE_PIN     26
-  #define ORIG_E0_ENABLE_PIN    14
-
-  #if ENABLED(LCD_I2C_PANELOLU2)
-    #define ORIG_FAN0_PIN         4
-  #endif
-
-#else
-
-  #define ORIG_HEATER_BED_PIN   14
-  #define ORIG_X_ENABLE_PIN     NoPin
-  #define ORIG_Y_ENABLE_PIN     NoPin
-  #define ORIG_Z_ENABLE_PIN     NoPin
-  #define ORIG_E0_ENABLE_PIN    NoPin
-
-#endif
 
 //#define SDSS               24
 
@@ -201,21 +169,13 @@
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920) //SPI GLCD 12864 ST7920 ( like [www.digole.com] ) For Melzi V2.0
-      #if MB(MELZI)
-        #define LCD_PINS_RS     30
-        #define LCD_PINS_ENABLE 2
-        #define LCD_PINS_D4     17
-        #define ORIG_BEEPER_PIN 27
-      #else
-        #define LCD_PINS_RS      4
-        #define LCD_PINS_ENABLE 17
-        #define LCD_PINS_D4     30
-        #define LCD_PINS_D5     29
-        #define LCD_PINS_D6     28
-        #define LCD_PINS_D7     27
-      #endif
+      #define LCD_PINS_RS      4
+      #define LCD_PINS_ENABLE 17
+      #define LCD_PINS_D4     30
+      #define LCD_PINS_D5     29
+      #define LCD_PINS_D6     28
+      #define LCD_PINS_D7     27
     #else // DOGM SPI LCD Support
-
       #define DOGLCD_A0         30
       #define DOGLCD_CS         29
       #define LCD_CONTRAST       1
@@ -240,12 +200,7 @@
   #define BTN_EN1               11
   #define BTN_EN2               10
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #if MB(MELZI)
-      #define BTN_ENC           29
-      #define LCD_SDSS          30
-    #else
-      #define BTN_ENC           30
-    #endif
+    #define BTN_ENC           30
   #else
     #define BTN_ENC             16
     #define LCD_SDSS            28

--- a/MK4duo/src/boards/62.h
+++ b/MK4duo/src/boards/62.h
@@ -20,25 +20,25 @@
 //###X_AXIS
 #define ORIG_X_STEP_PIN            15
 #define ORIG_X_DIR_PIN             21
-#define ORIG_X_ENABLE_PIN          NoPin
+#define ORIG_X_ENABLE_PIN          14
 #define ORIG_X_CS_PIN              NoPin
 
 //###Y_AXIS
 #define ORIG_Y_STEP_PIN            22
 #define ORIG_Y_DIR_PIN             23
-#define ORIG_Y_ENABLE_PIN          NoPin
+#define ORIG_Y_ENABLE_PIN          14
 #define ORIG_Y_CS_PIN              NoPin
 
 //###Z_AXIS
 #define ORIG_Z_STEP_PIN             3
 #define ORIG_Z_DIR_PIN              2
-#define ORIG_Z_ENABLE_PIN          NoPin
+#define ORIG_Z_ENABLE_PIN          26
 #define ORIG_Z_CS_PIN              NoPin
 
 //###EXTRUDER_0
 #define ORIG_E0_STEP_PIN            1
 #define ORIG_E0_DIR_PIN             0
-#define ORIG_E0_ENABLE_PIN         NoPin
+#define ORIG_E0_ENABLE_PIN         14
 #define ORIG_E0_CS_PIN             NoPin
 #define ORIG_SOL0_PIN              NoPin
 
@@ -116,7 +116,7 @@
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
-#define ORIG_HEATER_BED_PIN        NoPin
+#define ORIG_HEATER_BED_PIN        12
 #define ORIG_HEATER_CHAMBER_PIN    NoPin
 #define ORIG_COOLER_PIN            NoPin
 
@@ -156,44 +156,10 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
-#if !MB(SANGUINOLOLU_11)
-  #define SANGUINOLOLU_V_1_2
+#if ENABLED(LCD_I2C_PANELOLU2)
+  #define ORIG_FAN0_PIN         4 // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
 #endif
-
-#if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
-  #define ORIG_FAN0_PIN           4 // Works for Panelolu2 too
-  #if MB(MELZI)
-    #define LED_PIN             27
-  #elif MB(STB_11)
-    #define LCD_BACKLIGHT_PIN   17 // LCD backlight LED
-  #endif
-#endif
-
-#if ENABLED(SANGUINOLOLU_V_1_2)
-
-  #define ORIG_HEATER_BED_PIN   12 // (bed)
-  #define ORIG_X_ENABLE_PIN     14
-  #define ORIG_Y_ENABLE_PIN     14
-  #define ORIG_Z_ENABLE_PIN     26
-  #define ORIG_E0_ENABLE_PIN    14
-
-  #if ENABLED(LCD_I2C_PANELOLU2)
-    #define ORIG_FAN0_PIN         4 // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
-  #endif
-
-#else
-
-  #define ORIG_HEATER_BED_PIN   14  // (bed)
-  #define ORIG_X_ENABLE_PIN     NoPin
-  #define ORIG_Y_ENABLE_PIN     NoPin
-  #define ORIG_Z_ENABLE_PIN     NoPin
-  #define ORIG_E0_ENABLE_PIN    NoPin
-
-#endif
-
 /**
  * On some broken versions of the Sanguino libraries the pin definitions are wrong,
  * which then needs SDSS as pin 24. But you should upgrade your Sanguino libraries! See #368.
@@ -209,19 +175,12 @@
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920)
-      #if MB(MELZI)
-        #define LCD_PINS_RS     30
-        #define LCD_PINS_ENABLE 29
-        #define LCD_PINS_D4     17
-        #define ORIG_BEEPER_PIN 27
-      #else
-        #define LCD_PINS_RS      4
-        #define LCD_PINS_ENABLE 17
-        #define LCD_PINS_D4     30
-        #define LCD_PINS_D5     29
-        #define LCD_PINS_D6     28
-        #define LCD_PINS_D7     27
-      #endif
+      #define LCD_PINS_RS      4
+      #define LCD_PINS_ENABLE 17
+      #define LCD_PINS_D4     30
+      #define LCD_PINS_D5     29
+      #define LCD_PINS_D6     28
+      #define LCD_PINS_D7     27
     #else
 
       #define DOGLCD_A0         30
@@ -248,12 +207,7 @@
   #define BTN_EN1               11
   #define BTN_EN2               10
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #if MB(MELZI)
-      #define BTN_ENC           29
-      #define LCD_SDSS          30
-    #else
-      #define BTN_ENC           30
-    #endif
+    #define BTN_ENC           30
   #else
     #define BTN_ENC             16
     #define LCD_SDSS            28

--- a/MK4duo/src/boards/63.h
+++ b/MK4duo/src/boards/63.h
@@ -116,7 +116,7 @@
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
-#define ORIG_HEATER_BED_PIN        NoPin
+#define ORIG_HEATER_BED_PIN        14
 #define ORIG_HEATER_CHAMBER_PIN    NoPin
 #define ORIG_COOLER_PIN            NoPin
 
@@ -130,7 +130,7 @@
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
 //###FAN
-#define ORIG_FAN0_PIN              NoPin
+#define ORIG_FAN0_PIN               4 // Works for Panelolu2 too
 #define ORIG_FAN1_PIN              NoPin
 #define ORIG_FAN2_PIN              NoPin
 #define ORIG_FAN3_PIN              NoPin
@@ -144,7 +144,7 @@
 //###MISC
 #define ORIG_PS_ON_PIN             NoPin
 #define ORIG_BEEPER_PIN            NoPin
-#define LED_PIN                    NoPin
+#define LED_PIN                    27
 #define SDPOWER_PIN                NoPin
 #define SD_DETECT_PIN              NoPin
 #define SDSS                       31
@@ -156,44 +156,7 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
-#if !MB(SANGUINOLOLU_11)
-  #define SANGUINOLOLU_V_1_2
-#endif
-
-#if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
-  #define ORIG_FAN0_PIN           4 // Works for Panelolu2 too
-  #if MB(MELZI)
-    #define LED_PIN             27
-  #elif MB(STB_11)
-    #define LCD_BACKLIGHT_PIN   17 // LCD backlight LED
-  #endif
-#endif
-
-#if ENABLED(SANGUINOLOLU_V_1_2)
-
-  #define ORIG_HEATER_BED_PIN   12 // (bed)
-  #define ORIG_X_ENABLE_PIN     14
-  #define ORIG_Y_ENABLE_PIN     14
-  #define ORIG_Z_ENABLE_PIN     26
-  #define ORIG_E0_ENABLE_PIN    14
-
-  #if ENABLED(LCD_I2C_PANELOLU2)
-    #define ORIG_FAN0_PIN         4 // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
-  #endif
-
-#else
-
-  #define ORIG_HEATER_BED_PIN   14  // (bed)
-  #define ORIG_X_ENABLE_PIN     NoPin
-  #define ORIG_Y_ENABLE_PIN     NoPin
-  #define ORIG_Z_ENABLE_PIN     NoPin
-  #define ORIG_E0_ENABLE_PIN    NoPin
-
-#endif
-
 /**
  * On some broken versions of the Sanguino libraries the pin definitions are wrong,
  * which then needs SDSS as pin 24. But you should upgrade your Sanguino libraries! See #368.
@@ -208,19 +171,10 @@
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920)
-      #if MB(MELZI)
-        #define LCD_PINS_RS     30
-        #define LCD_PINS_ENABLE 29
-        #define LCD_PINS_D4     17
-        #define ORIG_BEEPER_PIN 27
-      #else
-        #define LCD_PINS_RS      4
-        #define LCD_PINS_ENABLE 17
-        #define LCD_PINS_D4     30
-        #define LCD_PINS_D5     29
-        #define LCD_PINS_D6     28
-        #define LCD_PINS_D7     27
-      #endif
+      #define LCD_PINS_RS     30
+      #define LCD_PINS_ENABLE 29
+      #define LCD_PINS_D4     17
+      #define ORIG_BEEPER_PIN 27
     #else
 
       #define DOGLCD_A0         30
@@ -247,12 +201,8 @@
   #define BTN_EN1               11
   #define BTN_EN2               10
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #if MB(MELZI)
-      #define BTN_ENC           29
-      #define LCD_SDSS          30
-    #else
-      #define BTN_ENC           30
-    #endif
+    #define BTN_ENC           29
+    #define LCD_SDSS          30
   #else
     #define BTN_ENC             16
     #define LCD_SDSS            28

--- a/MK4duo/src/boards/64.h
+++ b/MK4duo/src/boards/64.h
@@ -116,7 +116,7 @@
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
-#define ORIG_HEATER_BED_PIN        NoPin
+#define ORIG_HEATER_BED_PIN        14
 #define ORIG_HEATER_CHAMBER_PIN    NoPin
 #define ORIG_COOLER_PIN            NoPin
 
@@ -130,7 +130,7 @@
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
 //###FAN
-#define ORIG_FAN0_PIN              NoPin
+#define ORIG_FAN0_PIN               4 // Works for Panelolu2 too
 #define ORIG_FAN1_PIN              NoPin
 #define ORIG_FAN2_PIN              NoPin
 #define ORIG_FAN3_PIN              NoPin
@@ -156,44 +156,8 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
-#if !MB(SANGUINOLOLU_11)
-  #define SANGUINOLOLU_V_1_2
-#endif
-
-#if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
-  #define ORIG_FAN0_PIN           4 // Works for Panelolu2 too
-  #if MB(MELZI)
-    #define LED_PIN             27
-  #elif MB(STB_11)
-    #define LCD_BACKLIGHT_PIN   17 // LCD backlight LED
-  #endif
-#endif
-
-#if ENABLED(SANGUINOLOLU_V_1_2)
-
-  #define ORIG_HEATER_BED_PIN   12 // (bed)
-  #define ORIG_X_ENABLE_PIN     14
-  #define ORIG_Y_ENABLE_PIN     14
-  #define ORIG_Z_ENABLE_PIN     26
-  #define ORIG_E0_ENABLE_PIN    14
-
-  #if ENABLED(LCD_I2C_PANELOLU2)
-    #define ORIG_FAN0_PIN         4 // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
-  #endif
-
-#else
-
-  #define ORIG_HEATER_BED_PIN   14  // (bed)
-  #define ORIG_X_ENABLE_PIN     NoPin
-  #define ORIG_Y_ENABLE_PIN     NoPin
-  #define ORIG_Z_ENABLE_PIN     NoPin
-  #define ORIG_E0_ENABLE_PIN    NoPin
-
-#endif
-
+#define LCD_BACKLIGHT_PIN   17 // LCD backlight LED
 /**
  * On some broken versions of the Sanguino libraries the pin definitions are wrong,
  * which then needs SDSS as pin 24. But you should upgrade your Sanguino libraries! See #368.
@@ -209,19 +173,12 @@
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920)
-      #if MB(MELZI)
-        #define LCD_PINS_RS     30
-        #define LCD_PINS_ENABLE 29
-        #define LCD_PINS_D4     17
-        #define ORIG_BEEPER_PIN 27
-      #else
-        #define LCD_PINS_RS      4
-        #define LCD_PINS_ENABLE 17
-        #define LCD_PINS_D4     30
-        #define LCD_PINS_D5     29
-        #define LCD_PINS_D6     28
-        #define LCD_PINS_D7     27
-      #endif
+      #define LCD_PINS_RS      4
+      #define LCD_PINS_ENABLE 17
+      #define LCD_PINS_D4     30
+      #define LCD_PINS_D5     29
+      #define LCD_PINS_D6     28
+      #define LCD_PINS_D7     27
     #else // DOGM SPI LCD Support
 
       #define DOGLCD_A0         30
@@ -248,12 +205,7 @@
   #define BTN_EN1               11
   #define BTN_EN2               10
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #if MB(MELZI)
-      #define BTN_ENC           29
-      #define LCD_SDSS          30
-    #else
-      #define BTN_ENC           30
-    #endif
+    #define BTN_ENC           30
   #else
     #define BTN_ENC             16
     #define LCD_SDSS            28

--- a/MK4duo/src/boards/65.h
+++ b/MK4duo/src/boards/65.h
@@ -116,7 +116,7 @@
 #define ORIG_HEATER_1_PIN          NoPin
 #define ORIG_HEATER_2_PIN          NoPin
 #define ORIG_HEATER_3_PIN          NoPin
-#define ORIG_HEATER_BED_PIN        NoPin
+#define ORIG_HEATER_BED_PIN        14
 #define ORIG_HEATER_CHAMBER_PIN    NoPin
 #define ORIG_COOLER_PIN            NoPin
 
@@ -130,7 +130,7 @@
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
 //###FAN
-#define ORIG_FAN0_PIN              NoPin
+#define ORIG_FAN0_PIN               4 // Works for Panelolu2 too
 #define ORIG_FAN1_PIN              NoPin
 #define ORIG_FAN2_PIN              NoPin
 #define ORIG_FAN3_PIN              NoPin
@@ -156,44 +156,7 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
-#if !MB(SANGUINOLOLU_11)
-  #define SANGUINOLOLU_V_1_2
-#endif
-
-#if MB(AZTEEG_X1) || MB(STB_11) || MB(MELZI)
-  #define ORIG_FAN0_PIN           4 // Works for Panelolu2 too
-  #if MB(MELZI)
-    #define LED_PIN             27
-  #elif MB(STB_11)
-    #define LCD_BACKLIGHT_PIN   17 // LCD backlight LED
-  #endif
-#endif
-
-#if ENABLED(SANGUINOLOLU_V_1_2)
-
-  #define ORIG_HEATER_BED_PIN   12 // (bed)
-  #define ORIG_X_ENABLE_PIN     14
-  #define ORIG_Y_ENABLE_PIN     14
-  #define ORIG_Z_ENABLE_PIN     26
-  #define ORIG_E0_ENABLE_PIN    14
-
-  #if ENABLED(LCD_I2C_PANELOLU2)
-    #define ORIG_FAN0_PIN         4 // Uses Transistor1 (PWM) on Panelolu2's Sanguino Adapter Board to drive the fan
-  #endif
-
-#else
-
-  #define ORIG_HEATER_BED_PIN   14  // (bed)
-  #define ORIG_X_ENABLE_PIN     NoPin
-  #define ORIG_Y_ENABLE_PIN     NoPin
-  #define ORIG_Z_ENABLE_PIN     NoPin
-  #define ORIG_E0_ENABLE_PIN    NoPin
-
-#endif
-
 /**
  * On some broken versions of the Sanguino libraries the pin definitions are wrong,
  * which then needs SDSS as pin 24. But you should upgrade your Sanguino libraries! See #368.
@@ -209,25 +172,12 @@
   #if ENABLED(DOGLCD)
 
     #if ENABLED(U8GLIB_ST7920)
-      #if MB(MELZI)
-        #define LCD_PINS_RS     30
-        #define LCD_PINS_ENABLE 29
-        #define LCD_PINS_D4     17
-        #define ORIG_BEEPER_PIN 27
-      #else
-        #define LCD_PINS_RS      4
-        #define LCD_PINS_ENABLE 17
-        #define LCD_PINS_D4     30
-        #define LCD_PINS_D5     29
-        #define LCD_PINS_D6     28
-        #define LCD_PINS_D7     27
-      #endif
-    #else // DOGM SPI LCD Support
-
-      #define DOGLCD_A0         30
-      #define DOGLCD_CS         29
-      #define LCD_CONTRAST       1
-    #endif
+      #define LCD_PINS_RS      4
+      #define LCD_PINS_ENABLE 17
+      #define LCD_PINS_D4     30
+      #define LCD_PINS_D5     29
+      #define LCD_PINS_D6     28
+      #define LCD_PINS_D7     27
 
     // Uncomment screen orientation
     #define LCD_SCREEN_ROT_0
@@ -248,12 +198,7 @@
   #define BTN_EN1               11
   #define BTN_EN2               10
   #if ENABLED(LCD_I2C_PANELOLU2)
-    #if MB(MELZI)
-      #define BTN_ENC           29
-      #define LCD_SDSS          30
-    #else
-      #define BTN_ENC           30
-    #endif
+    #define BTN_ENC           30
   #else
     #define BTN_ENC             16
     #define LCD_SDSS            28

--- a/MK4duo/src/boards/67.h
+++ b/MK4duo/src/boards/67.h
@@ -159,7 +159,7 @@
 
 
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN            66 // Do not use pin 53 if there is even the remote possibility of using Display/SD card
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/68.h
+++ b/MK4duo/src/boards/68.h
@@ -159,7 +159,7 @@
 
 
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN          66  // Do not use pin 49 as this is tied to the switch inside the SD card socket to detect if there is an SD card present
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/7.h
+++ b/MK4duo/src/boards/7.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 #if ENABLED(ULTRA_LCD)
 

--- a/MK4duo/src/boards/70.h
+++ b/MK4duo/src/boards/70.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 #if TEMP_SENSOR_0 == NoPin
   #define ORIG_TEMP_0_PIN          8   // ANALOG NUMBERING

--- a/MK4duo/src/boards/701.h
+++ b/MK4duo/src/boards/701.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define SHIFT_CLK           63
 #define SHIFT_LD            42

--- a/MK4duo/src/boards/702.h
+++ b/MK4duo/src/boards/702.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define LCD_PINS_RS NoPin
 #define LCD_PINS_ENABLE NoPin

--- a/MK4duo/src/boards/703.h
+++ b/MK4duo/src/boards/703.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define BTN_EN1                 44
 #define BTN_EN2                 45

--- a/MK4duo/src/boards/71.h
+++ b/MK4duo/src/boards/71.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define LCD_PINS_RS 24
 #define LCD_PINS_ENABLE 22
@@ -166,4 +165,3 @@
 #define LCD_PINS_D6 32
 #define LCD_PINS_D7 30
 //@@@
-

--- a/MK4duo/src/boards/72.h
+++ b/MK4duo/src/boards/72.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define MAX6675_SS_PIN            13
 #define SAFETY_TRIGGERED_PIN      28

--- a/MK4duo/src/boards/74.h
+++ b/MK4duo/src/boards/74.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 #if ENABLED(ULTIMAKERCONTROLLER) || ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) || ENABLED(G3D_PANEL) || ENABLED(MKS_MINI_12864)
   #define SDSUPPORT   // Force SD Card support on for these displays

--- a/MK4duo/src/boards/75.h
+++ b/MK4duo/src/boards/75.h
@@ -157,8 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 #if ENABLED(ULTIMAKERCONTROLLER) || ENABLED(REPRAP_DISCOUNT_SMART_CONTROLLER) || ENABLED(G3D_PANEL) || ENABLED(MKS_MINI_12864)
   #define SDSUPPORT   // Force SD Card support on for these displays

--- a/MK4duo/src/boards/77.h
+++ b/MK4duo/src/boards/77.h
@@ -159,7 +159,7 @@
 
 
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN              66
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/78.h
+++ b/MK4duo/src/boards/78.h
@@ -159,7 +159,7 @@
 
 
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN              66
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/79.h
+++ b/MK4duo/src/boards/79.h
@@ -159,7 +159,7 @@
 
 
 //###UNKNOWN_PINS
-#define MAX6675_SS_PIN              66
+#define MAX6675_SS_PIN             66
 //@@@
 
 //###IF_BLOCKS

--- a/MK4duo/src/boards/8.h
+++ b/MK4duo/src/boards/8.h
@@ -1,9 +1,8 @@
 /****************************************************************************************
-* 8 - 81
-* Teensylu 0.7 / Printrboard pin assignments (AT90USB1286)
+* 8
+* Teensylu 0.7 pin assignments (AT90USB1286)
 * Requires the Teensyduino software with Teensy++ 2.0 selected in Arduino IDE!
-  http://www.pjrc.com/teensy/teensyduino.html
-* See http://reprap.org/wiki/Printrboard for more info
+* http://www.pjrc.com/teensy/teensyduino.html
 ****************************************************************************************/
 
 //###CHIP
@@ -114,9 +113,9 @@
 #define ORIG_Z_PROBE_PIN           NoPin
 
 //###SINGLE_ENDSTOP
-#define X_STOP_PIN                 NoPin
-#define Y_STOP_PIN                 NoPin
-#define Z_STOP_PIN                 NoPin
+#define X_STOP_PIN                 13
+#define Y_STOP_PIN                 14
+#define Z_STOP_PIN                 15
 
 //###HEATER
 #define ORIG_HEATER_0_PIN          21
@@ -128,11 +127,11 @@
 #define ORIG_COOLER_PIN            NoPin
 
 //###TEMPERATURE
-#define ORIG_TEMP_0_PIN            NoPin
+#define ORIG_TEMP_0_PIN             7
 #define ORIG_TEMP_1_PIN            NoPin
 #define ORIG_TEMP_2_PIN            NoPin
 #define ORIG_TEMP_3_PIN            NoPin
-#define ORIG_TEMP_BED_PIN          NoPin
+#define ORIG_TEMP_BED_PIN           6
 #define ORIG_TEMP_CHAMBER_PIN      NoPin
 #define ORIG_TEMP_COOLER_PIN       NoPin
 
@@ -163,25 +162,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define AT90USB 1286  // Disable MarlinSerial etc.
-//@@@
-
-//###IF_BLOCKS
-// You may need to change ORIG_FAN0_PIN to 16 because MK4duo isn't using fastio.h
-// for the fan and Teensyduino uses a different pin mapping.
-#if MB(TEENSYLU)  // Teensylu
-  #define X_STOP_PIN         13
-  #define Y_STOP_PIN         14
-  #define Z_STOP_PIN         15
-  #define ORIG_TEMP_0_PIN     7
-  #define ORIG_TEMP_BED_PIN   6
-#else  // Printrboard
-  #define X_STOP_PIN         35
-  #define Y_STOP_PIN          8
-  #define Z_STOP_PIN         36
-  #define ORIG_TEMP_0_PIN     1
-  #define ORIG_TEMP_BED_PIN   0
-#endif
 //@@@

--- a/MK4duo/src/boards/80.h
+++ b/MK4duo/src/boards/80.h
@@ -157,7 +157,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define LCD_PINS_RS        19
 #define LCD_PINS_ENABLE    42
@@ -169,4 +168,3 @@
 #define BTN_EN2            12
 #define BTN_ENC            43
 //@@@
-

--- a/MK4duo/src/boards/89.h
+++ b/MK4duo/src/boards/89.h
@@ -156,8 +156,6 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
-
 //###IF_BLOCKS
 #define LCD_PINS_RS               28 // st9720 CS
 #define LCD_PINS_ENABLE           17 // st9720 DAT

--- a/MK4duo/src/boards/9.h
+++ b/MK4duo/src/boards/9.h
@@ -156,6 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/90.h
+++ b/MK4duo/src/boards/90.h
@@ -182,6 +182,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/91.h
+++ b/MK4duo/src/boards/91.h
@@ -183,9 +183,7 @@
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
 
-
 //###UNKNOWN_PINS
 #define I2C_SCL       16
 #define I2C_SDA       17
 //@@@
-

--- a/MK4duo/src/boards/99.h
+++ b/MK4duo/src/boards/99.h
@@ -151,6 +151,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-

--- a/MK4duo/src/boards/999.h
+++ b/MK4duo/src/boards/999.h
@@ -156,6 +156,3 @@
 //###LASER
 #define ORIG_LASER_PWR_PIN         NoPin
 #define ORIG_LASER_PWM_PIN         NoPin
-
-
-


### PR DESCRIPTION
@MagoKimbra ATTENTION: in Boards.h there are two boards defined which DO NOT EXISTS!

They are:
``#define BOARD_MELZI_MAKR3D      66    // Melzi with ATmega1284 (MaKr3d version) [[MANCA FILE 66.h]]``
``#define BOARD_GEN6_DELUXE       51    // Gen6 deluxe [[MANCA FILE 51.h]]``

Please check them...