### PR TITLE
Fix 70.h, 701.h, 702.h, 703.h

### DIFF
--- a/MK4duo/src/boards/70.h
+++ b/MK4duo/src/boards/70.h
@@ -158,15 +158,14 @@
 #define ORIG_LASER_PWM_PIN         NoPin
 
 //###IF_BLOCKS
-#if TEMP_SENSOR_0 == NoPin
-  #define ORIG_TEMP_0_PIN          8   // ANALOG NUMBERING
+#if TEMP_SENSOR_0 == -1 //thermocouple with AD595 or AD597
+  #define ORIG_TEMP_0_PIN           8
 #else
-  #define ORIG_TEMP_0_PIN         13   // ANALOG NUMBERING
+  #define ORIG_TEMP_0_PIN          13
 #endif
 
 #if ENABLED(ULTRA_LCD)
   #if ENABLED(NEWPANEL)
-  //arduino pin which triggers an piezzo beeper
 
     #define LCD_PINS_RS 16
     #define LCD_PINS_ENABLE 17

--- a/MK4duo/src/boards/701.h
+++ b/MK4duo/src/boards/701.h
@@ -158,26 +158,26 @@
 #define ORIG_LASER_PWM_PIN         NoPin
 
 //###UNKNOWN_PINS
-#define SHIFT_CLK           63
-#define SHIFT_LD            42
-#define SHIFT_OUT           17
-#define SHIFT_EN            17
+#define SHIFT_CLK                  63
+#define SHIFT_LD                   42
+#define SHIFT_OUT                  17
+#define SHIFT_EN                   17
 //@@@
 
 //###IF_BLOCKS
-#if TEMP_SENSOR_0 ==        NoPin
+#if TEMP_SENSOR_0 == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_0_PIN    4
 #else
   #define ORIG_TEMP_0_PIN   13
 #endif
 
-#if TEMP_SENSOR_1 == NoPin
+#if TEMP_SENSOR_1 == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_1_PIN    8
 #else
   #define ORIG_TEMP_1_PIN   15
 #endif
 
-#if TEMP_SENSOR_BED ==      NoPin
+#if TEMP_SENSOR_BED == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_BED_PIN  8
 #else
   #define ORIG_TEMP_BED_PIN 14

--- a/MK4duo/src/boards/702.h
+++ b/MK4duo/src/boards/702.h
@@ -158,24 +158,24 @@
 #define ORIG_LASER_PWM_PIN         NoPin
 
 //###UNKNOWN_PINS
-#define LCD_PINS_RS NoPin
-#define LCD_PINS_ENABLE NoPin
-#define LCD_PINS_D4 NoPin
-#define LCD_PINS_D5 NoPin
-#define LCD_PINS_D6 NoPin
-#define LCD_PINS_D7 NoPin
-#define BTN_EN1 NoPin
-#define BTN_EN2 NoPin
-#define BTN_ENC NoPin //the click
-#define BLEN_C 2
-#define BLEN_B 1
-#define BLEN_A 0
+#define LCD_PINS_RS                NoPin
+#define LCD_PINS_ENABLE            NoPin
+#define LCD_PINS_D4                NoPin
+#define LCD_PINS_D5                NoPin
+#define LCD_PINS_D6                NoPin
+#define LCD_PINS_D7                NoPin
+#define BTN_EN1                    NoPin
+#define BTN_EN2                    NoPin
+#define BTN_ENC                    NoPin //the click
+#define BLEN_C                      2
+#define BLEN_B                      1
+#define BLEN_A                      0
 //@@@
 
 //###IF_BLOCKS
-#if TEMP_SENSOR_0 == NoPin
-  #define ORIG_TEMP_0_PIN 5 // ANALOG NUMBERING
+#if TEMP_SENSOR_0 == -1 //thermocouple with AD595 or AD597
+  #define ORIG_TEMP_0_PIN 5
 #else
-  #define ORIG_TEMP_0_PIN 7 // ANALOG NUMBERING
+  #define ORIG_TEMP_0_PIN 7
 #endif
 //@@@

--- a/MK4duo/src/boards/703.h
+++ b/MK4duo/src/boards/703.h
@@ -158,31 +158,31 @@
 #define ORIG_LASER_PWM_PIN         NoPin
 
 //###UNKNOWN_PINS
-#define BTN_EN1                 44
-#define BTN_EN2                 45
-#define BTN_ENC                 33
+#define BTN_EN1                    44
+#define BTN_EN2                    45
+#define BTN_ENC                    33
 //@@@
 
 //###IF_BLOCKS
-#if TEMP_SENSOR_0 == NoPin
+#if TEMP_SENSOR_0 == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_0_PIN       11
 #else
   #define ORIG_TEMP_0_PIN       15
 #endif
 
-#if TEMP_SENSOR_1 == NoPin
+#if TEMP_SENSOR_1 == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_1_PIN       10
 #else
   #define ORIG_TEMP_1_PIN       13
 #endif
 
-#if TEMP_SENSOR_2 == NoPin
+#if TEMP_SENSOR_2 == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_2_PIN        9
 #else
   #define ORIG_TEMP_2_PIN       12
 #endif
 
-#if TEMP_SENSOR_BED == NoPin
+#if TEMP_SENSOR_BED == -1 //thermocouple with AD595 or AD597
   #define ORIG_TEMP_BED_PIN      8
 #else
   #define ORIG_TEMP_BED_PIN     14


### PR DESCRIPTION
This is the continuation of PR #505.
Replacing `NoPin` macro with "-1" inside board files caused the replacement of some "-1" which didn't refer to pins but to temperature sensor types. This can create some confusion.