### PR TITLE
Fix HD44780 compile error

### DIFF
--- a/MK4duo/src/lcd/ultralcd/dogm/ultralcd_dogm.cpp
+++ b/MK4duo/src/lcd/ultralcd/dogm/ultralcd_dogm.cpp
@@ -389,8 +389,9 @@ void LcdUI::clear_lcd() { } // Automatically cleared by Picture Loop
 
       constexpr uint8_t maxlen = LCD_WIDTH - 1;
       PGM_P outstr = longFilename;
-      if (longFilename[0]) {
-        #if ENABLED(SCROLL_LONG_FILENAMES)
+
+      #if ENABLED(SCROLL_LONG_FILENAMES)
+        if (longFilename[0]) {
           static uint8_t filename_scroll_hash;
           if (isSelected) {
             uint8_t name_hash = row;
@@ -401,13 +402,11 @@ void LcdUI::clear_lcd() { } // Automatically cleared by Picture Loop
               lcdui.filename_scroll_max = MAX(0, utf8_strlen(longFilename) - maxlen);  // Update the scroll limit
               lcdui.filename_scroll_pos = 0;                                           // Reset scroll to the start
               lcdui.status_update_delay = 8;                                       // Don't scroll right away
-  
-  
             }
             outstr += lcdui.filename_scroll_pos;
           }
-        #endif
-      }
+        }
+      #endif
 
       if (isDir) lcd_put_wchar(LCD_STR_FOLDER[0]);
 

--- a/MK4duo/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp
+++ b/MK4duo/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp
@@ -1034,7 +1034,7 @@ void LcdUI::draw_status_screen() {
 
   #if HAS_SD_SUPPORT
 
-    void draw_sd_menu_item(const bool isSelected, const uint8_t row, PGM_P const pstr, PGM_P longFilename, const uint8_t concat, const char post_char) {
+    void draw_sd_menu_item(const bool isSelected, const uint8_t row, PGM_P const pstr, PGM_P longFilename, const bool isDir) {
       const char post_char = isDir ? LCD_STR_FOLDER[0] : ' ',
                  sel_char = isSelected ? '>' : ' ';
       UNUSED(pstr);
@@ -1043,8 +1043,9 @@ void LcdUI::draw_status_screen() {
 
       uint8_t n = LCD_WIDTH - 2;
       PGM_P outstr = longFilename;
-      if (longFilename[0]) {
-        #if ENABLED(SCROLL_LONG_FILENAMES)
+
+      #if ENABLED(SCROLL_LONG_FILENAMES)
+        if (longFilename[0]) {
           static uint8_t filename_scroll_hash;
           if (isSelected) {
             uint8_t name_hash = row;
@@ -1058,10 +1059,8 @@ void LcdUI::draw_status_screen() {
             }
             outstr += lcdui.filename_scroll_pos;
           }
-        #else
-          longFilename[n] = '\0'; // cutoff at screen edge
-        #endif
-      }
+        }
+      #endif
 
       lcd_moveto(0, row);
       lcd_put_wchar(sel_char);


### PR DESCRIPTION
This PR fixes this errors:

sketch/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp: In function 'void draw_sd_menu_item(bool, uint8_t, const char*, const char*, uint8_t, char)':
/sketch/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp:1038:18: error: declaration of 'const char post_char' shadows a parameter
``` cpp
const char post_char = isDir ? LCD_STR_FOLDER[0] : ' ',
```

sketch/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp:1038:30: error: 'isDir' was not declared in this scope
``` cpp
const char post_char = isDir ? LCD_STR_FOLDER[0] : ' ',
```

sketch/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp:1042:21: error: 'sel_char' was not declared in this scope
``` cpp
lcd_put_wchar(sel_char);
```

sketch/src/lcd/ultralcd/hd44780/ultralcd_hd44780.cpp:1062:27: error: assignment of read-only location '*(longFilename + ((sizetype)n))'
``` cpp
longFilename[n] = '\0'; // cutoff at screen edge
```