### PR TITLE
Fix #652 also for 4_3_8 version

### DIFF
--- a/MK4duo/src/core/commands/gcode/temperature/m192.h
+++ b/MK4duo/src/core/commands/gcode/temperature/m192.h
@@ -38,8 +38,8 @@
     if (printer.debugDryrun() || printer.debugSimulation()) return;
 
     LCD_MESSAGEPGM(MSG_COOLER_COOLING);
-    bool no_wait_for_heating = parser.seen('S');
-    if (no_wait_for_heating || parser.seen('R'))
+    const bool no_wait_for_cooling = parser.seen('S');
+    if (no_wait_for_cooling || parser.seen('R'))
       heaters[COOLER_INDEX].setTarget(parser.value_celsius());
     else return;
 

--- a/MK4duo/src/core/temperature/sanitycheck.h
+++ b/MK4duo/src/core/temperature/sanitycheck.h
@@ -84,7 +84,7 @@
     #error "DEPENDENCY ERROR: Missing setting CHAMBER_MINTEMP."
   #endif
   #if !HAS_HEATER_CHAMBER
-    #error "DEPENDENCY ERROR: Cannot enable TEMP_SENSOR_CHAMBER and not HEATER_CHAMBER_PIN."
+    #error "DEPENDENCY ERROR: Cannot enable TEMP_SENSOR_CHAMBER without HEATER_CHAMBER_PIN."
   #endif
 #endif
 #if TEMP_SENSOR_COOLER != 0
@@ -95,7 +95,7 @@
     #error "DEPENDENCY ERROR: Missing setting COOLER_MINTEMP."
   #endif
   #if !HAS_HEATER_COOLER
-    #error "DEPENDENCY ERROR: Cannot enable TEMP_SENSOR_COOLER and not COOLER_PIN."
+    #error "DEPENDENCY ERROR: Cannot enable TEMP_SENSOR_COOLER without HEATER_COOLER_PIN."
   #endif
 #endif
 #if DISABLED(PREHEAT_1_TEMP_HOTEND)


### PR DESCRIPTION
Hi @MagoKimbra. This fixes #652. **_I've already fixed this for `4_3_7` branch with the same changes._** Now we need to add these changes also to `master` and then to `4_3_8`.
It's a very simple fix... in `m192.h` there's a variable with the wrong name.
The error was introduced in `4_3_7` version