### PR TITLE
Fix #633

### DIFF
--- a/MK4duo/src/core/heater/sensor/sensor.h
+++ b/MK4duo/src/core/heater/sensor/sensor.h
@@ -210,9 +210,22 @@ typedef struct {
 
         millis_t ms = millis();
 
-        if (PENDING(ms, next_max31855_ms)) return max31855_temp;
+        if (PENDING(ms, next_max31855_ms)) return (int)max31855_temp;
 
         next_max31855_ms = ms + 250u;
+
+        #if ENABLED(CPU_32_BIT)
+          HAL::spiBegin();
+        #else
+          CBI(
+          #ifdef PRR
+            PRR
+          #elif defined(PRR0)
+            PRR0
+          #endif
+              , PRSPI);
+          SPCR = _BV(MSTR) | _BV(SPE) | _BV(SPR0);
+        #endif
 
         HAL::digitalWrite(pin, LOW); // enable TT_MAX31855
 


### PR DESCRIPTION
MAX_31855 SPI not initialized if no other SPI device is defined