### PR TITLE
TMC2130 diag1 pushpull/open

### DIFF
--- a/MK4duo/src/language/language_en.h
+++ b/MK4duo/src/language/language_en.h
@@ -1390,8 +1390,8 @@
 #ifndef MSG_NEED_TUNE_PID
   #define MSG_NEED_TUNE_PID                   _UxGT("Need Tune PID")
 #endif
-#ifndef MSG_DO_YOU_ARE_SHURE
-  #define MSG_DO_YOU_ARE_SHURE                _UxGT("Do you are shure?")
+#ifndef MSG_ARE_YOU_SURE
+  #define MSG_ARE_YOU_SURE                    _UxGT("Are you sure?")
 #endif
 #ifndef MSG_YES
   #define MSG_YES                             _UxGT("Yes")

--- a/MK4duo/src/language/language_it.h
+++ b/MK4duo/src/language/language_it.h
@@ -480,7 +480,7 @@
 #define MSG_RESTORING_POS                   _UxGT("Ripristino posizione")
 #define MSG_INVALID_POS_SLOT                _UxGT("Slot invalido, slot totali:")
 #define MSG_NEED_TUNE_PID                   _UxGT("Necessita Tune PID")
-#define MSG_DO_YOU_ARE_SHURE                _UxGT("Sei sicuro?")
+#define MSG_ARE_YOU_SURE                    _UxGT("Sei sicuro?")
 #define MSG_YES                             _UxGT("Si")
 #define MSG_NO                              _UxGT("No")
 

--- a/MK4duo/src/lcd/menu/menu_main.cpp
+++ b/MK4duo/src/lcd/menu/menu_main.cpp
@@ -3,7 +3,7 @@
  *
  * Based on Marlin, Sprinter and grbl
  * Copyright (C) 2011 Camiel Gubbels / Erik van der Zalm
- * Copyright (C) 2013 Alberto Cotronei @MagoKimbra
+ * Copyright (C) 2019 Alberto Cotronei @MagoKimbra
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -32,7 +32,7 @@ void menu_stop_print() {
   lcdui.encoder_direction_menus();
   START_MENU();
   MENU_BACK(MSG_MAIN);
-  STATIC_ITEM(MSG_DO_YOU_ARE_SHURE);
+  STATIC_ITEM(MSG_ARE_YOU_SURE);
   MENU_ITEM(function, MSG_YES, lcdui.stop_print);
   MENU_ITEM(function, MSG_NO, lcdui.return_to_status);
   END_MENU();
@@ -83,7 +83,7 @@ void menu_stop_print() {
       lcdui.encoderPosition = 2 * ENCODER_STEPS_PER_MENU_ITEM;
       START_MENU();
       MENU_BACK(MSG_MAIN);
-      STATIC_ITEM(MSG_DO_YOU_ARE_SHURE);
+      STATIC_ITEM(MSG_ARE_YOU_SURE);
       MENU_ITEM(function, MSG_YES, UploadNewFirmware);
       MENU_ITEM(submenu, MSG_NO, menu_main);
       END_MENU();


### PR DESCRIPTION
I figured out that the TMC2130 diag1 pin is in opendrain "mode". I use a DUE "ultratonics" board. The internal pullup is not strong enough against the opendrain from the TMC2130. Even with inverted Endstops and pullups, Sensorless homing is not working because the max Voltage is about 1.3V. So I would like to have a switch so choose between diag1 as pushpull or open drain output. I guess the most users would like to have the pushpull diag1 except the  EinsyRambo users. Here is a good discussion on the Marlin fork https://github.com/MarlinFirmware/Marlin/issues/10294

( this is my first request, sorry if I did a mistake, please advise me)